### PR TITLE
Schema-driven diagnostics extraction (closes #9)

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -11,9 +11,10 @@
 #' @param draws A `posterior::draws_array` returned by [nutpie_sample()].
 #' @return A `nutpie_diagnostics` object (a named list with a print method).
 #'   Commonly available scalar fields: `diverging`, `tuning`, `maxdepth_reached`
-#'   (logical); `depth`, `n_steps`, `chain`, `draw`, `index_in_trajectory`,
-#'   `logp`, `energy`, `energy_error`, `step_size`, `step_size_bar`,
-#'   `mean_tree_accept`, `mean_tree_accept_sym` (numeric).
+#'   (logical); `depth`, `n_steps`, `chain`, `draw`, `index_in_trajectory`
+#'   (integer when fits in `i32`, else numeric); `logp`, `energy`,
+#'   `energy_error`, `step_size`, `step_size_bar`, `mean_tree_accept`,
+#'   `mean_tree_accept_sym` (numeric).
 #'   List-valued fields (one entry per draw, `NULL` when not recorded):
 #'   `unconstrained_draw`, `gradient`. With `store_mass_matrix = TRUE`:
 #'   `mass_matrix_inv`. With `store_divergences = TRUE`: `divergence_start`,
@@ -41,21 +42,21 @@ print.nutpie_diagnostics <- function(x, ...) {
               n, n_per_chain, num_chains))
 
   if (!is.null(x$diverging)) {
-    n_div <- sum(x$diverging)
+    n_div <- sum(x$diverging, na.rm = TRUE)
     cat(sprintf("  Divergences:   %d", n_div))
     if (n_div > 0) cat(sprintf(" (%.1f%%)", 100 * n_div / n))
     cat("\n")
   }
   if (!is.null(x$maxdepth_reached)) {
-    n_md <- sum(x$maxdepth_reached)
+    n_md <- sum(x$maxdepth_reached, na.rm = TRUE)
     cat(sprintf("  Max-treedepth hits: %d", n_md))
     if (n_md > 0) cat(sprintf(" (%.1f%%)", 100 * n_md / n))
     cat("\n")
   } else if (!is.null(x$depth)) {
-    cat(sprintf("  Max treedepth: %d\n", max(x$depth)))
+    cat(sprintf("  Max treedepth: %d\n", max(x$depth, na.rm = TRUE)))
   }
   if (!is.null(x$mean_tree_accept)) {
-    cat(sprintf("  Mean accept:   %.3f\n", mean(x$mean_tree_accept)))
+    cat(sprintf("  Mean accept:   %.3f\n", mean(x$mean_tree_accept, na.rm = TRUE)))
   }
   if (!is.null(x$step_size_bar)) {
     step_sizes <- x$step_size_bar[seq(n_per_chain, n, by = n_per_chain)]
@@ -63,7 +64,7 @@ print.nutpie_diagnostics <- function(x, ...) {
                 paste(sprintf("%.4f", step_sizes), collapse = ", ")))
   }
 
-  if (!is.null(x$diverging) && sum(x$diverging) > 0) {
+  if (!is.null(x$diverging) && sum(x$diverging, na.rm = TRUE) > 0) {
     cat("\n")
     cat("  Warning: divergent transitions detected. Consider increasing\n")
     cat("  target_accept or reparameterizing the model.\n")

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -2,13 +2,11 @@
 #'
 #' Diagnostics are extracted directly from the nuts-rs sample-stats schema, so
 #' the exact set of fields depends on the installed nuts-rs version and the
-#' sampling options used. Integer-typed Arrow columns (e.g. `depth`,
-#' `n_steps`, `chain`, `draw`, `index_in_trajectory`) are returned as R
-#' `integer` when every value fits in `i32` (with `NA_integer_` for nulls) —
-#' the typical case for a NUTS run. If a value would overflow, the column
-#' falls back to `numeric` (`NA_real_` for nulls). Floating-point columns
-#' (`logp`, `energy`, `step_size`, etc.) are always `numeric`, so a Float64
-#' field can never be silently truncated by the integer dispatch.
+#' sampling options used. Count fields (`depth`, `n_steps`, `chain`, `draw`,
+#' `index_in_trajectory`) are returned as R `integer` when every value fits
+#' in `i32`, else as `numeric`; floating-point fields (`logp`, `energy`,
+#' `step_size`, etc.) are always `numeric`. `NA`s use the matching sentinel
+#' (`NA_integer_` / `NA_real_`).
 #'
 #' @param draws A `posterior::draws_array` returned by [nutpie_sample()].
 #' @return A `nutpie_diagnostics` object (a named list with a print method).

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1,13 +1,22 @@
 #' Extract sampler diagnostics from nutpie draws
 #'
+#' Diagnostics are extracted directly from the nuts-rs sample-stats schema, so
+#' the exact set of fields depends on the installed nuts-rs version and the
+#' sampling options used. All numeric fields are returned as R `double`, even
+#' when the underlying Arrow column is integer-typed (depth, n_steps, chain,
+#' draw, etc.) — this avoids silent truncation.
+#'
 #' @param draws A `posterior::draws_array` returned by [nutpie_sample()].
 #' @return A `nutpie_diagnostics` object (a named list with a print method).
-#'   Fields include `diverging`, `depth`, `energy`, `energy_error`, `logp`,
-#'   `n_steps`, `step_size_bar`, and `mean_tree_accept`. When
-#'   `store_divergences = TRUE` was used, additional list columns
-#'   `divergence_start`, `divergence_end`, `divergence_momentum`, and
-#'   `divergence_start_gradient` are included. When `store_mass_matrix = TRUE`
-#'   was used, a `mass_matrix_inv` list column is included.
+#'   Commonly available scalar fields: `diverging`, `tuning`, `maxdepth_reached`
+#'   (logical); `depth`, `n_steps`, `chain`, `draw`, `index_in_trajectory`,
+#'   `logp`, `energy`, `energy_error`, `step_size`, `step_size_bar`,
+#'   `mean_tree_accept`, `mean_tree_accept_sym` (numeric).
+#'   List-valued fields (one entry per draw, `NULL` when not recorded):
+#'   `unconstrained_draw`, `gradient`. With `store_mass_matrix = TRUE`:
+#'   `mass_matrix_inv`. With `store_divergences = TRUE`: `divergence_start`,
+#'   `divergence_end`, `divergence_momentum`, `divergence_start_gradient`
+#'   (only present when at least one draw diverged).
 #' @export
 nutpie_diagnostics <- function(draws) {
   diag <- attr(draws, "diagnostics")
@@ -21,33 +30,46 @@ nutpie_diagnostics <- function(draws) {
 
 #' @export
 print.nutpie_diagnostics <- function(x, ...) {
-  n <- length(x$diverging)
+  n <- length(x$diverging %||% x[[1]])
   num_chains <- attr(x, "num_chains") %||% 1L
   n_per_chain <- n %/% num_chains
-
-  n_div <- sum(x$diverging)
-  max_depth <- max(x$depth)
-  mean_accept <- mean(x$mean_tree_accept)
-  step_sizes <- x$step_size_bar[seq(n_per_chain, n, by = n_per_chain)]
 
   cat("Sampler diagnostics\n")
   cat(sprintf("  Draws:         %d (%d per chain, %d chains)\n",
               n, n_per_chain, num_chains))
-  cat(sprintf("  Divergences:   %d", n_div))
-  if (n_div > 0) cat(sprintf(" (%.1f%%)", 100 * n_div / n))
-  cat("\n")
-  cat(sprintf("  Max treedepth: %d\n", max_depth))
-  cat(sprintf("  Mean accept:   %.3f\n", mean_accept))
-  cat(sprintf("  Step size:     %s\n",
-              paste(sprintf("%.4f", step_sizes), collapse = ", ")))
 
-  if (n_div > 0) {
+  if (!is.null(x$diverging)) {
+    n_div <- sum(x$diverging)
+    cat(sprintf("  Divergences:   %d", n_div))
+    if (n_div > 0) cat(sprintf(" (%.1f%%)", 100 * n_div / n))
+    cat("\n")
+  }
+  if (!is.null(x$maxdepth_reached)) {
+    n_md <- sum(x$maxdepth_reached)
+    cat(sprintf("  Max-treedepth hits: %d", n_md))
+    if (n_md > 0) cat(sprintf(" (%.1f%%)", 100 * n_md / n))
+    cat("\n")
+  } else if (!is.null(x$depth)) {
+    cat(sprintf("  Max treedepth: %d\n", max(x$depth)))
+  }
+  if (!is.null(x$mean_tree_accept)) {
+    cat(sprintf("  Mean accept:   %.3f\n", mean(x$mean_tree_accept)))
+  }
+  if (!is.null(x$step_size_bar)) {
+    step_sizes <- x$step_size_bar[seq(n_per_chain, n, by = n_per_chain)]
+    cat(sprintf("  Step size:     %s\n",
+                paste(sprintf("%.4f", step_sizes), collapse = ", ")))
+  }
+
+  if (!is.null(x$diverging) && sum(x$diverging) > 0) {
     cat("\n")
     cat("  Warning: divergent transitions detected. Consider increasing\n")
     cat("  target_accept or reparameterizing the model.\n")
   }
 
-  cat("\nUse `str(nutpie_diagnostics(draws))` for raw diagnostic vectors.\n")
+  cat(sprintf("\nAvailable fields: %s\n",
+              paste(names(x), collapse = ", ")))
+  cat("Use `str(nutpie_diagnostics(draws))` for raw diagnostic vectors.\n")
   invisible(x)
 }
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -2,9 +2,13 @@
 #'
 #' Diagnostics are extracted directly from the nuts-rs sample-stats schema, so
 #' the exact set of fields depends on the installed nuts-rs version and the
-#' sampling options used. All numeric fields are returned as R `double`, even
-#' when the underlying Arrow column is integer-typed (depth, n_steps, chain,
-#' draw, etc.) — this avoids silent truncation.
+#' sampling options used. Integer-typed Arrow columns (e.g. `depth`,
+#' `n_steps`, `chain`, `draw`, `index_in_trajectory`) are returned as R
+#' `integer` when every value fits in `i32` (with `NA_integer_` for nulls) —
+#' the typical case for a NUTS run. If a value would overflow, the column
+#' falls back to `numeric` (`NA_real_` for nulls). Floating-point columns
+#' (`logp`, `energy`, `step_size`, etc.) are always `numeric`, so a Float64
+#' field can never be silently truncated by the integer dispatch.
 #'
 #' @param draws A `posterior::draws_array` returned by [nutpie_sample()].
 #' @return A `nutpie_diagnostics` object (a named list with a print method).

--- a/man/nutpie_diagnostics.Rd
+++ b/man/nutpie_diagnostics.Rd
@@ -12,9 +12,10 @@ nutpie_diagnostics(draws)
 \value{
 A \code{nutpie_diagnostics} object (a named list with a print method).
 Commonly available scalar fields: \code{diverging}, \code{tuning}, \code{maxdepth_reached}
-(logical); \code{depth}, \code{n_steps}, \code{chain}, \code{draw}, \code{index_in_trajectory},
-\code{logp}, \code{energy}, \code{energy_error}, \code{step_size}, \code{step_size_bar},
-\code{mean_tree_accept}, \code{mean_tree_accept_sym} (numeric).
+(logical); \code{depth}, \code{n_steps}, \code{chain}, \code{draw}, \code{index_in_trajectory}
+(integer when fits in \code{i32}, else numeric); \code{logp}, \code{energy},
+\code{energy_error}, \code{step_size}, \code{step_size_bar}, \code{mean_tree_accept},
+\code{mean_tree_accept_sym} (numeric).
 List-valued fields (one entry per draw, \code{NULL} when not recorded):
 \code{unconstrained_draw}, \code{gradient}. With \code{store_mass_matrix = TRUE}:
 \code{mass_matrix_inv}. With \code{store_divergences = TRUE}: \code{divergence_start},

--- a/man/nutpie_diagnostics.Rd
+++ b/man/nutpie_diagnostics.Rd
@@ -24,7 +24,11 @@ List-valued fields (one entry per draw, \code{NULL} when not recorded):
 \description{
 Diagnostics are extracted directly from the nuts-rs sample-stats schema, so
 the exact set of fields depends on the installed nuts-rs version and the
-sampling options used. All numeric fields are returned as R \code{double}, even
-when the underlying Arrow column is integer-typed (depth, n_steps, chain,
-draw, etc.) — this avoids silent truncation.
+sampling options used. Integer-typed Arrow columns (e.g. \code{depth},
+\code{n_steps}, \code{chain}, \code{draw}, \code{index_in_trajectory}) are returned as R
+\code{integer} when every value fits in \code{i32} (with \code{NA_integer_} for nulls) —
+the typical case for a NUTS run. If a value would overflow, the column
+falls back to \code{numeric} (\code{NA_real_} for nulls). Floating-point columns
+(\code{logp}, \code{energy}, \code{step_size}, etc.) are always \code{numeric}, so a Float64
+field can never be silently truncated by the integer dispatch.
 }

--- a/man/nutpie_diagnostics.Rd
+++ b/man/nutpie_diagnostics.Rd
@@ -24,11 +24,9 @@ List-valued fields (one entry per draw, \code{NULL} when not recorded):
 \description{
 Diagnostics are extracted directly from the nuts-rs sample-stats schema, so
 the exact set of fields depends on the installed nuts-rs version and the
-sampling options used. Integer-typed Arrow columns (e.g. \code{depth},
-\code{n_steps}, \code{chain}, \code{draw}, \code{index_in_trajectory}) are returned as R
-\code{integer} when every value fits in \code{i32} (with \code{NA_integer_} for nulls) —
-the typical case for a NUTS run. If a value would overflow, the column
-falls back to \code{numeric} (\code{NA_real_} for nulls). Floating-point columns
-(\code{logp}, \code{energy}, \code{step_size}, etc.) are always \code{numeric}, so a Float64
-field can never be silently truncated by the integer dispatch.
+sampling options used. Count fields (\code{depth}, \code{n_steps}, \code{chain}, \code{draw},
+\code{index_in_trajectory}) are returned as R \code{integer} when every value fits
+in \code{i32}, else as \code{numeric}; floating-point fields (\code{logp}, \code{energy},
+\code{step_size}, etc.) are always \code{numeric}. \code{NA}s use the matching sentinel
+(\code{NA_integer_} / \code{NA_real_}).
 }

--- a/man/nutpie_diagnostics.Rd
+++ b/man/nutpie_diagnostics.Rd
@@ -11,13 +11,20 @@ nutpie_diagnostics(draws)
 }
 \value{
 A \code{nutpie_diagnostics} object (a named list with a print method).
-Fields include \code{diverging}, \code{depth}, \code{energy}, \code{energy_error}, \code{logp},
-\code{n_steps}, \code{step_size_bar}, and \code{mean_tree_accept}. When
-\code{store_divergences = TRUE} was used, additional list columns
-\code{divergence_start}, \code{divergence_end}, \code{divergence_momentum}, and
-\code{divergence_start_gradient} are included. When \code{store_mass_matrix = TRUE}
-was used, a \code{mass_matrix_inv} list column is included.
+Commonly available scalar fields: \code{diverging}, \code{tuning}, \code{maxdepth_reached}
+(logical); \code{depth}, \code{n_steps}, \code{chain}, \code{draw}, \code{index_in_trajectory},
+\code{logp}, \code{energy}, \code{energy_error}, \code{step_size}, \code{step_size_bar},
+\code{mean_tree_accept}, \code{mean_tree_accept_sym} (numeric).
+List-valued fields (one entry per draw, \code{NULL} when not recorded):
+\code{unconstrained_draw}, \code{gradient}. With \code{store_mass_matrix = TRUE}:
+\code{mass_matrix_inv}. With \code{store_divergences = TRUE}: \code{divergence_start},
+\code{divergence_end}, \code{divergence_momentum}, \code{divergence_start_gradient}
+(only present when at least one draw diverged).
 }
 \description{
-Extract sampler diagnostics from nutpie draws
+Diagnostics are extracted directly from the nuts-rs sample-stats schema, so
+the exact set of fields depends on the installed nuts-rs version and the
+sampling options used. All numeric fields are returned as R \code{double}, even
+when the underlying Arrow column is integer-typed (depth, n_steps, chain,
+draw, etc.) — this avoids silent truncation.
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1,6 +1,10 @@
 #![allow(non_snake_case)]
 
-use arrow::array::Array;
+use arrow::array::{
+    Array, BooleanArray, Float32Array, Float64Array, Int32Array, Int64Array, LargeListArray,
+    UInt32Array, UInt64Array,
+};
+use arrow::datatypes::DataType;
 use extendr_api::prelude::*;
 use nuts_rs::{
     ArrowConfig, ArrowTrace, ChainProgress, CpuLogpFunc, CpuMath, DiagGradNutsSettings, HasDims,
@@ -409,13 +413,8 @@ fn sample_stan(
 
     let draws_robj = build_draws_matrix(&results, ndim, num_tune, n_draws_per_chain, &param_names)?;
 
-    let diagnostics = extract_diagnostics(
-        &results,
-        num_tune,
-        n_draws_per_chain,
-        store_divergences,
-        store_mass_matrix,
-    );
+    // Extract post-warmup diagnostics (schema-driven)
+    let diagnostics = extract_diagnostics(&results, num_tune, n_draws_per_chain)?;
 
     let warmup_draws_robj: Robj = if save_warmup {
         build_draws_matrix(&results, ndim, 0, num_tune, &param_names)?
@@ -423,7 +422,7 @@ fn sample_stan(
         ().into_robj()
     };
     let warmup_diagnostics_robj: Robj = if save_warmup {
-        extract_diagnostics(&results, 0, num_tune, store_divergences, store_mass_matrix).into_robj()
+        extract_diagnostics(&results, 0, num_tune)?.into_robj()
     } else {
         ().into_robj()
     };
@@ -493,177 +492,153 @@ fn build_draws_matrix(
     Ok(robj)
 }
 
+/// Convert an Arrow column window (across all chains) into an R object.
+///
+/// All numeric Arrow types (Float64/32, Int64/32, UInt64/32) become R `double`.
+/// Integer Arrow types are *not* cast to R integer — i32 can silently truncate
+/// values like a Float64 logp that gets misrouted, which is exactly the kind of
+/// bug schema-driven extraction is meant to prevent.
+///
+/// Returns `None` for unsupported Arrow types so the caller can warn-and-skip.
+fn column_to_robj(
+    cols: &[&dyn Array],
+    dtype: &DataType,
+    skip: usize,
+    n_draws: usize,
+) -> Option<Robj> {
+    let total = cols.len() * n_draws;
+
+    macro_rules! scalar_to_doubles {
+        ($arr_ty:ty) => {{
+            let mut out: Vec<f64> = Vec::with_capacity(total);
+            for c in cols {
+                let arr = c.as_any().downcast_ref::<$arr_ty>()?;
+                for i in 0..n_draws {
+                    let row = skip + i;
+                    out.push(if arr.is_null(row) {
+                        f64::NAN
+                    } else {
+                        arr.value(row) as f64
+                    });
+                }
+            }
+            Some(out.into_robj())
+        }};
+    }
+
+    match dtype {
+        DataType::Boolean => {
+            let mut out: Vec<bool> = Vec::with_capacity(total);
+            for c in cols {
+                let arr = c.as_any().downcast_ref::<BooleanArray>()?;
+                for i in 0..n_draws {
+                    let row = skip + i;
+                    out.push(!arr.is_null(row) && arr.value(row));
+                }
+            }
+            Some(out.into_robj())
+        }
+        DataType::Float64 => scalar_to_doubles!(Float64Array),
+        DataType::Float32 => scalar_to_doubles!(Float32Array),
+        DataType::Int64 => scalar_to_doubles!(Int64Array),
+        DataType::UInt64 => scalar_to_doubles!(UInt64Array),
+        DataType::Int32 => scalar_to_doubles!(Int32Array),
+        DataType::UInt32 => scalar_to_doubles!(UInt32Array),
+        DataType::LargeList(inner) if matches!(inner.data_type(), DataType::Float64) => {
+            let mut out: Vec<Robj> = Vec::with_capacity(total);
+            for c in cols {
+                let list_arr = c.as_any().downcast_ref::<LargeListArray>()?;
+                for i in 0..n_draws {
+                    let row = skip + i;
+                    if list_arr.is_null(row) {
+                        out.push(().into_robj());
+                        continue;
+                    }
+                    let inner_arr = list_arr.value(row);
+                    let values = inner_arr.as_any().downcast_ref::<Float64Array>()?;
+                    if values.is_empty() {
+                        out.push(().into_robj());
+                    } else {
+                        let v: Vec<f64> = (0..values.len()).map(|j| values.value(j)).collect();
+                        out.push(v.into_robj());
+                    }
+                }
+            }
+            Some(List::from_values(out).into_robj())
+        }
+        _ => None,
+    }
+}
+
 /// Extract diagnostic statistics from sample_stats RecordBatches.
-/// Returns a named R list with one vector per diagnostic field.
+///
+/// Schema-driven: iterates `sample_stats.schema().fields()` and dispatches each
+/// column through `column_to_robj`. Columns that are entirely null in the
+/// requested window are dropped (covers e.g. `mass_matrix_inv` when
+/// `store_mass_matrix = false`). Unsupported Arrow types are skipped with a
+/// warning rather than failing the whole call.
 fn extract_diagnostics(
     results: &[ArrowTrace],
     skip: usize,
     n_draws: usize,
-    include_divergence_detail: bool,
-    include_mass_matrix: bool,
-) -> List {
-    let n_chains = results.len();
-    let total = n_draws * n_chains;
-
-    let mut diverging = vec![false; total];
-    let mut depth = vec![0i32; total];
-    let mut energy = vec![0.0f64; total];
-    let mut energy_error = vec![0.0f64; total];
-    let mut logp = vec![0.0f64; total];
-    let mut n_steps = vec![0i32; total];
-    let mut step_size_bar = vec![0.0f64; total];
-    let mut mean_tree_accept = vec![0.0f64; total];
-
-    fn null_robj_vec(n: usize, include: bool) -> Vec<Robj> {
-        if include { (0..n).map(|_| ().into_robj()).collect() } else { vec![] }
+) -> Result<List> {
+    if results.is_empty() {
+        return Ok(List::from_values(Vec::<Robj>::new()));
     }
 
-    let mut div_start = null_robj_vec(total, include_divergence_detail);
-    let mut div_end = null_robj_vec(total, include_divergence_detail);
-    let mut div_momentum = null_robj_vec(total, include_divergence_detail);
-    let mut div_start_grad = null_robj_vec(total, include_divergence_detail);
-    let mut mass_matrix = null_robj_vec(total, include_mass_matrix);
+    let schema = results[0].sample_stats.schema();
+    let mut names: Vec<String> = Vec::new();
+    let mut values: Vec<Robj> = Vec::new();
 
-    for (chain_idx, trace) in results.iter().enumerate() {
-        let stats = &trace.sample_stats;
-        let offset = chain_idx * n_draws;
+    for field in schema.fields() {
+        let name = field.name();
 
-        extract_bool(stats, "diverging", &mut diverging, offset, skip, n_draws);
-        extract_u64_as_i32(stats, "depth", &mut depth, offset, skip, n_draws);
-        extract_f64(stats, "energy", &mut energy, offset, skip, n_draws);
-        extract_f64(stats, "energy_error", &mut energy_error, offset, skip, n_draws);
-        extract_f64(stats, "logp", &mut logp, offset, skip, n_draws);
-        extract_u64_as_i32(stats, "n_steps", &mut n_steps, offset, skip, n_draws);
-        extract_f64(stats, "step_size_bar", &mut step_size_bar, offset, skip, n_draws);
-        extract_f64(stats, "mean_tree_accept", &mut mean_tree_accept, offset, skip, n_draws);
-
-        if include_divergence_detail {
-            extract_large_list_f64(stats, "divergence_start", &mut div_start, offset, skip, n_draws);
-            extract_large_list_f64(stats, "divergence_end", &mut div_end, offset, skip, n_draws);
-            extract_large_list_f64(stats, "divergence_momentum", &mut div_momentum, offset, skip, n_draws);
-            extract_large_list_f64(stats, "divergence_start_gradient", &mut div_start_grad, offset, skip, n_draws);
-        }
-
-        if include_mass_matrix {
-            extract_large_list_f64(stats, "mass_matrix_inv", &mut mass_matrix, offset, skip, n_draws);
-        }
-    }
-
-    fn optional_list(values: Vec<Robj>, include: bool) -> Robj {
-        if include { List::from_values(values).into_robj() } else { ().into_robj() }
-    }
-
-    let div_start_robj = optional_list(div_start, include_divergence_detail);
-    let div_end_robj = optional_list(div_end, include_divergence_detail);
-    let div_momentum_robj = optional_list(div_momentum, include_divergence_detail);
-    let div_start_grad_robj = optional_list(div_start_grad, include_divergence_detail);
-    let mass_matrix_robj = optional_list(mass_matrix, include_mass_matrix);
-
-    list!(
-        diverging = diverging,
-        depth = depth,
-        energy = energy,
-        energy_error = energy_error,
-        logp = logp,
-        n_steps = n_steps,
-        step_size_bar = step_size_bar,
-        mean_tree_accept = mean_tree_accept,
-        divergence_start = div_start_robj,
-        divergence_end = div_end_robj,
-        divergence_momentum = div_momentum_robj,
-        divergence_start_gradient = div_start_grad_robj,
-        mass_matrix_inv = mass_matrix_robj
-    )
-}
-
-fn extract_bool(
-    batch: &arrow::record_batch::RecordBatch,
-    name: &str,
-    out: &mut [bool],
-    offset: usize,
-    skip: usize,
-    n: usize,
-) {
-    if let Some(col) = batch.column_by_name(name) {
-        if let Some(arr) = col.as_any().downcast_ref::<arrow::array::BooleanArray>() {
-            for i in 0..n {
-                out[offset + i] = arr.value(skip + i);
-            }
-        }
-    }
-}
-
-fn extract_u64_as_i32(
-    batch: &arrow::record_batch::RecordBatch,
-    name: &str,
-    out: &mut [i32],
-    offset: usize,
-    skip: usize,
-    n: usize,
-) {
-    if let Some(col) = batch.column_by_name(name) {
-        if let Some(arr) = col.as_any().downcast_ref::<arrow::array::UInt64Array>() {
-            for i in 0..n {
-                out[offset + i] = arr.value(skip + i) as i32;
-            }
-        }
-    }
-}
-
-fn extract_f64(
-    batch: &arrow::record_batch::RecordBatch,
-    name: &str,
-    out: &mut [f64],
-    offset: usize,
-    skip: usize,
-    n: usize,
-) {
-    if let Some(col) = batch.column_by_name(name) {
-        if let Some(arr) = col.as_any().downcast_ref::<arrow::array::Float64Array>() {
-            for i in 0..n {
-                out[offset + i] = arr.value(skip + i);
-            }
-        }
-    }
-}
-
-/// Extract a LargeList(Float64) column into a Vec<Robj>.
-/// Each element is either NULL (for null/empty list entries) or a numeric vector.
-fn extract_large_list_f64(
-    batch: &arrow::record_batch::RecordBatch,
-    name: &str,
-    out: &mut [Robj],
-    offset: usize,
-    skip: usize,
-    n: usize,
-) {
-    if let Some(col) = batch.column_by_name(name) {
-        if let Some(list_arr) = col
-            .as_any()
-            .downcast_ref::<arrow::array::LargeListArray>()
-        {
-            for i in 0..n {
-                let row = skip + i;
-                if list_arr.is_null(row) {
-                    out[offset + i] = ().into_robj();
-                } else {
-                    let inner = list_arr.value(row);
-                    if let Some(values) = inner
-                        .as_any()
-                        .downcast_ref::<arrow::array::Float64Array>()
-                    {
-                        if values.is_empty() {
-                            out[offset + i] = ().into_robj();
-                        } else {
-                            let vec: Vec<f64> =
-                                (0..values.len()).map(|j| values.value(j)).collect();
-                            out[offset + i] = vec.into_robj();
-                        }
-                    }
+        let mut cols: Vec<&dyn Array> = Vec::with_capacity(results.len());
+        let mut all_present = true;
+        for trace in results {
+            match trace.sample_stats.column_by_name(name) {
+                Some(c) => cols.push(c.as_ref()),
+                None => {
+                    all_present = false;
+                    break;
                 }
             }
         }
+        if !all_present {
+            continue;
+        }
+
+        // Drop columns that are entirely null in the requested window
+        // (e.g. mass_matrix_inv / divergence_* when their flags are off).
+        let any_non_null = cols.iter().any(|c| {
+            (skip..skip + n_draws).any(|row| row < c.len() && !c.is_null(row))
+        });
+        if !any_non_null {
+            continue;
+        }
+
+        match column_to_robj(&cols, field.data_type(), skip, n_draws) {
+            Some(robj) => {
+                names.push(name.clone());
+                values.push(robj);
+            }
+            None => {
+                rprintln!(
+                    "nutpieR: skipping diagnostic '{}' — unsupported Arrow type {:?}",
+                    name,
+                    field.data_type()
+                );
+            }
+        }
     }
+
+    let lst = List::from_values(values);
+    let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+    let mut robj = lst.into_robj();
+    robj.set_attrib("names", name_refs)
+        .map_err(|e| Error::Other(format!("failed to set diagnostics names: {e}")))?;
+    let lst: List = robj.try_into().map_err(r_err)?;
+    Ok(lst)
 }
 
 /// Open a BridgeStan model and return an `ExternalPtr<BSHandle>` that caches

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -494,10 +494,11 @@ fn build_draws_matrix(
 
 /// Convert an Arrow column window (across all chains) into an R object.
 ///
-/// All numeric Arrow types (Float64/32, Int64/32, UInt64/32) become R `double`.
-/// Integer Arrow types are *not* cast to R integer — i32 can silently truncate
-/// values like a Float64 logp that gets misrouted, which is exactly the kind of
-/// bug schema-driven extraction is meant to prevent.
+/// `Float*` columns always become R `double`. `Int*`/`UInt*` columns become R
+/// `integer` when every non-null value fits in `(i32::MIN, i32::MAX]`
+/// (`i32::MIN` is reserved as `NA_INTEGER`); otherwise they fall back to
+/// `double`. `logp` is `Float64` in the nuts-rs schema, so it can never reach
+/// the integer arm — no risk of silently truncating a misrouted logp.
 ///
 /// Returns `None` for unsupported Arrow types so the caller can warn-and-skip.
 fn column_to_robj(
@@ -508,59 +509,111 @@ fn column_to_robj(
 ) -> Option<Robj> {
     let total = cols.len() * n_draws;
 
-    macro_rules! scalar_to_doubles {
+    macro_rules! build_doubles {
         ($arr_ty:ty) => {{
-            let mut out: Vec<f64> = Vec::with_capacity(total);
+            let mut out = Doubles::new(total);
+            let dest: &mut [Rfloat] = &mut out;
+            let mut i = 0;
             for c in cols {
                 let arr = c.as_any().downcast_ref::<$arr_ty>()?;
-                for i in 0..n_draws {
-                    let row = skip + i;
-                    out.push(if arr.is_null(row) {
-                        f64::NAN
+                for k in 0..n_draws {
+                    let row = skip + k;
+                    dest[i] = if arr.is_null(row) {
+                        Rfloat::na()
                     } else {
-                        arr.value(row) as f64
-                    });
+                        Rfloat::from(arr.value(row) as f64)
+                    };
+                    i += 1;
                 }
             }
-            Some(out.into_robj())
+            Some(out.into())
+        }};
+    }
+
+    macro_rules! build_int_or_double {
+        ($arr_ty:ty, $fits:expr) => {{
+            let mut fits_i32 = true;
+            'fit: for c in cols {
+                let arr = c.as_any().downcast_ref::<$arr_ty>()?;
+                for k in 0..n_draws {
+                    let row = skip + k;
+                    if arr.is_null(row) {
+                        continue;
+                    }
+                    if !$fits(arr.value(row)) {
+                        fits_i32 = false;
+                        break 'fit;
+                    }
+                }
+            }
+            if fits_i32 {
+                let mut out = Integers::new(total);
+                let dest: &mut [Rint] = &mut out;
+                let mut i = 0;
+                for c in cols {
+                    let arr = c.as_any().downcast_ref::<$arr_ty>()?;
+                    for k in 0..n_draws {
+                        let row = skip + k;
+                        dest[i] = if arr.is_null(row) {
+                            Rint::na()
+                        } else {
+                            Rint::from(arr.value(row) as i32)
+                        };
+                        i += 1;
+                    }
+                }
+                Some(out.into())
+            } else {
+                build_doubles!($arr_ty)
+            }
         }};
     }
 
     match dtype {
         DataType::Boolean => {
-            let mut out: Vec<bool> = Vec::with_capacity(total);
+            let mut out = Logicals::new(total);
+            let dest: &mut [Rbool] = &mut out;
+            let mut i = 0;
             for c in cols {
                 let arr = c.as_any().downcast_ref::<BooleanArray>()?;
-                for i in 0..n_draws {
-                    let row = skip + i;
-                    out.push(!arr.is_null(row) && arr.value(row));
+                for k in 0..n_draws {
+                    let row = skip + k;
+                    dest[i] = if arr.is_null(row) {
+                        Rbool::na()
+                    } else {
+                        Rbool::from(arr.value(row))
+                    };
+                    i += 1;
                 }
             }
-            Some(out.into_robj())
+            Some(out.into())
         }
-        DataType::Float64 => scalar_to_doubles!(Float64Array),
-        DataType::Float32 => scalar_to_doubles!(Float32Array),
-        DataType::Int64 => scalar_to_doubles!(Int64Array),
-        DataType::UInt64 => scalar_to_doubles!(UInt64Array),
-        DataType::Int32 => scalar_to_doubles!(Int32Array),
-        DataType::UInt32 => scalar_to_doubles!(UInt32Array),
+        DataType::Float64 => build_doubles!(Float64Array),
+        DataType::Float32 => build_doubles!(Float32Array),
+        DataType::Int64 => build_int_or_double!(
+            Int64Array,
+            |v: i64| v > i32::MIN as i64 && v <= i32::MAX as i64
+        ),
+        DataType::UInt64 => build_int_or_double!(UInt64Array, |v: u64| v <= i32::MAX as u64),
+        DataType::Int32 => build_int_or_double!(Int32Array, |v: i32| v > i32::MIN),
+        DataType::UInt32 => build_int_or_double!(UInt32Array, |v: u32| v <= i32::MAX as u32),
         DataType::LargeList(inner) if matches!(inner.data_type(), DataType::Float64) => {
             let mut out: Vec<Robj> = Vec::with_capacity(total);
             for c in cols {
                 let list_arr = c.as_any().downcast_ref::<LargeListArray>()?;
-                for i in 0..n_draws {
-                    let row = skip + i;
+                for k in 0..n_draws {
+                    let row = skip + k;
                     if list_arr.is_null(row) {
                         out.push(().into_robj());
                         continue;
                     }
                     let inner_arr = list_arr.value(row);
                     let values = inner_arr.as_any().downcast_ref::<Float64Array>()?;
-                    if values.is_empty() {
+                    let slice: &[f64] = values.values();
+                    if slice.is_empty() {
                         out.push(().into_robj());
                     } else {
-                        let v: Vec<f64> = (0..values.len()).map(|j| values.value(j)).collect();
-                        out.push(v.into_robj());
+                        out.push(slice.to_vec().into_robj());
                     }
                 }
             }
@@ -590,23 +643,13 @@ fn extract_diagnostics(
     let mut names: Vec<String> = Vec::new();
     let mut values: Vec<Robj> = Vec::new();
 
-    for field in schema.fields() {
+    for (idx, field) in schema.fields().iter().enumerate() {
         let name = field.name();
 
-        let mut cols: Vec<&dyn Array> = Vec::with_capacity(results.len());
-        let mut all_present = true;
-        for trace in results {
-            match trace.sample_stats.column_by_name(name) {
-                Some(c) => cols.push(c.as_ref()),
-                None => {
-                    all_present = false;
-                    break;
-                }
-            }
-        }
-        if !all_present {
-            continue;
-        }
+        let cols: Vec<&dyn Array> = results
+            .iter()
+            .map(|t| t.sample_stats.column(idx).as_ref())
+            .collect();
 
         // Drop columns that are entirely null in the requested window
         // (e.g. mass_matrix_inv / divergence_* when their flags are off).
@@ -632,13 +675,8 @@ fn extract_diagnostics(
         }
     }
 
-    let lst = List::from_values(values);
-    let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
-    let mut robj = lst.into_robj();
-    robj.set_attrib("names", name_refs)
-        .map_err(|e| Error::Other(format!("failed to set diagnostics names: {e}")))?;
-    let lst: List = robj.try_into().map_err(r_err)?;
-    Ok(lst)
+    let pairs: Vec<(&str, Robj)> = names.iter().map(String::as_str).zip(values).collect();
+    Ok(List::from_pairs(pairs))
 }
 
 /// Open a BridgeStan model and return an `ExternalPtr<BSHandle>` that caches

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -532,26 +532,18 @@ fn column_to_robj(
 
     macro_rules! build_int_or_double {
         ($arr_ty:ty, $fits:expr) => {{
-            let mut fits_i32 = true;
-            'fit: for c in cols {
-                let arr = c.as_any().downcast_ref::<$arr_ty>()?;
-                for k in 0..n_draws {
-                    let row = skip + k;
-                    if arr.is_null(row) {
-                        continue;
-                    }
-                    if !$fits(arr.value(row)) {
-                        fits_i32 = false;
-                        break 'fit;
-                    }
-                }
-            }
+            let arrs: Vec<&$arr_ty> = cols
+                .iter()
+                .map(|c| c.as_any().downcast_ref::<$arr_ty>())
+                .collect::<Option<Vec<_>>>()?;
+            let fits_i32 = arrs.iter().all(|arr| {
+                (skip..skip + n_draws).all(|row| arr.is_null(row) || $fits(arr.value(row)))
+            });
             if fits_i32 {
                 let mut out = Integers::new(total);
                 let dest: &mut [Rint] = &mut out;
                 let mut i = 0;
-                for c in cols {
-                    let arr = c.as_any().downcast_ref::<$arr_ty>()?;
+                for arr in &arrs {
                     for k in 0..n_draws {
                         let row = skip + k;
                         dest[i] = if arr.is_null(row) {
@@ -613,7 +605,8 @@ fn column_to_robj(
                     if slice.is_empty() {
                         out.push(().into_robj());
                     } else {
-                        out.push(slice.to_vec().into_robj());
+                        let robj: Robj = Doubles::from_values(slice.iter().copied()).into();
+                        out.push(robj);
                     }
                 }
             }

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -135,7 +135,7 @@ test_that("nutpie_diagnostics returns expected fields", {
   expect_equal(length(diag$logp), 200)
 
   expect_type(diag$diverging, "logical")
-  expect_type(diag$depth, "double")
+  expect_type(diag$depth, "integer")
   expect_type(diag$energy, "double")
   expect_true(all(diag$depth > 0))
   expect_true(all(is.finite(diag$logp)))
@@ -162,11 +162,16 @@ test_that("schema-driven extraction exposes nuts-rs fields", {
     expect_true(f %in% names(diag), info = paste("missing field:", f))
   }
 
-  # All numeric Arrow types are surfaced as R double — never integer.
-  # Integer cast is the trap that lets a Float64 logp silently truncate.
-  numeric_fields <- c("depth", "n_steps", "chain", "draw",
-                      "index_in_trajectory", "logp", "energy", "step_size")
-  for (f in numeric_fields) {
+  # Int*/UInt* columns become R integer when values fit in i32; Float* are
+  # always double. logp is Float64 in the schema, so the integer arm can
+  # never reach it — the silent-truncation trap is structurally avoided.
+  integer_fields <- c("depth", "n_steps", "chain", "draw",
+                      "index_in_trajectory")
+  for (f in integer_fields) {
+    expect_type(diag[[f]], "integer")
+  }
+  double_fields <- c("logp", "energy", "step_size")
+  for (f in double_fields) {
     expect_type(diag[[f]], "double")
   }
 

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -130,18 +130,71 @@ test_that("nutpie_diagnostics returns expected fields", {
     expect_true(field %in% names(diag), info = paste("missing field:", field))
   }
 
-  # Each diagnostic vector should have num_draws * num_chains elements
   expect_equal(length(diag$diverging), 200)
   expect_equal(length(diag$depth), 200)
   expect_equal(length(diag$logp), 200)
 
-  # Sanity checks
   expect_type(diag$diverging, "logical")
-  expect_type(diag$depth, "integer")
+  expect_type(diag$depth, "double")
   expect_type(diag$energy, "double")
   expect_true(all(diag$depth > 0))
   expect_true(all(is.finite(diag$logp)))
   expect_true(all(diag$mean_tree_accept >= 0 & diag$mean_tree_accept <= 1))
+})
+
+test_that("schema-driven extraction exposes nuts-rs fields", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+
+  draws <- nutpie_sample(test_models$bernoulli,
+    data = list(N = 10, y = c(0, 1, 0, 0, 0, 0, 0, 0, 0, 1)),
+    num_draws = 100, num_chains = 2, seed = 42, refresh = 0
+  )
+  diag <- nutpie_diagnostics(draws)
+
+  # Fields nuts-rs always emits in sample_stats
+  always_present <- c(
+    "depth", "maxdepth_reached", "index_in_trajectory", "logp", "energy",
+    "chain", "draw", "energy_error", "unconstrained_draw", "gradient",
+    "step_size", "step_size_bar", "mean_tree_accept", "mean_tree_accept_sym",
+    "n_steps", "tuning", "diverging"
+  )
+  for (f in always_present) {
+    expect_true(f %in% names(diag), info = paste("missing field:", f))
+  }
+
+  # All numeric Arrow types are surfaced as R double — never integer.
+  # Integer cast is the trap that lets a Float64 logp silently truncate.
+  numeric_fields <- c("depth", "n_steps", "chain", "draw",
+                      "index_in_trajectory", "logp", "energy", "step_size")
+  for (f in numeric_fields) {
+    expect_type(diag[[f]], "double")
+  }
+
+  expect_type(diag$maxdepth_reached, "logical")
+  expect_type(diag$tuning, "logical")
+  expect_type(diag$unconstrained_draw, "list")
+  expect_type(diag$gradient, "list")
+
+  # 1-d bernoulli model: each draw's unconstrained_draw / gradient is length 1
+  expect_equal(length(diag$unconstrained_draw[[1]]), 1)
+  expect_equal(length(diag$gradient[[1]]), 1)
+})
+
+test_that("logp is non-zero floating-point — guards silent default-fill", {
+  # If extract_diagnostics ever silently fails to populate logp (renamed
+  # column, dtype mismatch, etc.) it stays at the zero-init buffer and prints
+  # as integers. This test catches that class of bug.
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+
+  draws <- nutpie_sample(test_models$bernoulli,
+    data = list(N = 10, y = c(0, 1, 0, 0, 0, 0, 0, 0, 0, 1)),
+    num_draws = 100, num_chains = 2, seed = 42, refresh = 0
+  )
+  lp <- nutpie_diagnostics(draws)$logp
+
+  expect_type(lp, "double")
+  expect_true(any(lp != 0))
+  expect_true(any(abs(lp - round(lp)) > 1e-8))
 })
 
 test_that("nutpie_diagnostics errors on non-nutpie object", {
@@ -225,6 +278,14 @@ test_that("save_warmup returns warmup draws", {
   warmup_diag <- nutpie_warmup_diagnostics(draws)
   expect_type(warmup_diag, "list")
   expect_equal(length(warmup_diag$diverging), 100)  # 50 * 2 chains
+
+  # Warmup diagnostics should use the same schema-driven extractor.
+  expect_true("logp" %in% names(warmup_diag))
+  expect_true("tuning" %in% names(warmup_diag))
+  expect_type(warmup_diag$logp, "double")
+  expect_true(any(warmup_diag$logp != 0))
+  # During warmup, tuning should be TRUE for at least some draws.
+  expect_true(any(warmup_diag$tuning))
 })
 
 test_that("nutpie_warmup_draws errors without save_warmup", {
@@ -254,22 +315,41 @@ test_that("cores parameter works", {
 
 # --- Item 7: store_divergences and store_mass_matrix ---
 
-test_that("store_divergences adds divergence detail fields", {
+test_that("store_divergences exposes divergence detail when divergences occur", {
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
 
+  # Force divergences via a tiny max_treedepth + low target_accept on a model
+  # that's easy to push into pathology. We don't always get divergences, so
+  # the test is conditional on actually having some.
   draws <- nutpie_sample(test_models$bernoulli,
     data = list(N = 10, y = c(0, 1, 0, 0, 0, 0, 0, 0, 0, 1)),
-    num_draws = 50, num_chains = 1, seed = 42, refresh = 0,
-    store_divergences = TRUE
+    num_draws = 200, num_chains = 4, seed = 42, refresh = 0,
+    store_divergences = TRUE, max_treedepth = 1, target_accept = 0.5
   )
-
   diag <- nutpie_diagnostics(draws)
+  skip_if_not(sum(diag$diverging) > 0, "no divergences in this run")
+
   expect_true("divergence_start" %in% names(diag))
   expect_true("divergence_end" %in% names(diag))
   expect_true("divergence_momentum" %in% names(diag))
   expect_true("divergence_start_gradient" %in% names(diag))
   expect_type(diag$divergence_start, "list")
-  expect_equal(length(diag$divergence_start), 50)
+  expect_equal(length(diag$divergence_start), length(diag$diverging))
+  # Non-NULL entries align with diverging draws
+  div_idx <- which(diag$diverging)
+  expect_true(all(!vapply(diag$divergence_start[div_idx], is.null, logical(1))))
+})
+
+test_that("store_divergences = FALSE drops all-null divergence list columns", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+
+  draws <- nutpie_sample(test_models$bernoulli,
+    data = list(N = 10, y = c(0, 1, 0, 0, 0, 0, 0, 0, 0, 1)),
+    num_draws = 50, num_chains = 1, seed = 42, refresh = 0
+  )
+  diag <- nutpie_diagnostics(draws)
+  expect_false("divergence_start" %in% names(diag))
+  expect_false("mass_matrix_inv" %in% names(diag))
 })
 
 test_that("store_mass_matrix adds mass_matrix_inv field", {
@@ -311,6 +391,20 @@ test_that("low_rank_modified_mass_matrix produces valid draws", {
   summ <- posterior::summarize_draws(draws)
   theta_mean <- summ$mean[summ$variable == "theta"]
   expect_true(abs(theta_mean - 0.25) < 0.1)
+})
+
+test_that("low_rank + store_mass_matrix surfaces mass matrix without errors", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+
+  draws <- nutpie_sample(test_models$bernoulli,
+    data = list(N = 10, y = c(0, 1, 0, 0, 0, 0, 0, 0, 0, 1)),
+    num_draws = 50, num_chains = 1, seed = 42, refresh = 0,
+    low_rank_modified_mass_matrix = TRUE, store_mass_matrix = TRUE
+  )
+  diag <- nutpie_diagnostics(draws)
+  expect_true("logp" %in% names(diag))
+  expect_type(diag$logp, "double")
+  expect_true(any(diag$logp != 0))
 })
 
 # --- Issue #4: scalar init_mean auto-expansion ---

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -113,7 +113,11 @@ test_that("nutpie_sample accepts sampling parameters", {
   expect_equal(posterior::nchains(draws), 2)
 })
 
-test_that("nutpie_diagnostics returns expected fields", {
+test_that("nutpie_diagnostics exposes the load-bearing fields", {
+  # Narrow contract: only the fields nutpieR's own code, docs, and the
+  # standard MCMC convergence-diagnostic vocabulary depend on. Schema
+  # additions in nuts-rs pass silently; the generic shape invariants are
+  # checked separately below.
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
 
   draws <- nutpie_sample(test_models$bernoulli,
@@ -124,25 +128,29 @@ test_that("nutpie_diagnostics returns expected fields", {
   diag <- nutpie_diagnostics(draws)
   expect_type(diag, "list")
 
-  expected_fields <- c("diverging", "depth", "energy", "energy_error",
-                       "logp", "n_steps", "step_size_bar", "mean_tree_accept")
-  for (field in expected_fields) {
+  must_have <- c("diverging", "depth", "logp", "energy", "n_steps",
+                 "step_size_bar", "mean_tree_accept")
+  for (field in must_have) {
     expect_true(field %in% names(diag), info = paste("missing field:", field))
   }
 
-  expect_equal(length(diag$diverging), 200)
-  expect_equal(length(diag$depth), 200)
-  expect_equal(length(diag$logp), 200)
-
   expect_type(diag$diverging, "logical")
   expect_type(diag$depth, "integer")
+  expect_type(diag$n_steps, "integer")
+  expect_type(diag$logp, "double")
   expect_type(diag$energy, "double")
+
   expect_true(all(diag$depth > 0))
   expect_true(all(is.finite(diag$logp)))
   expect_true(all(diag$mean_tree_accept >= 0 & diag$mean_tree_accept <= 1))
 })
 
-test_that("schema-driven extraction exposes nuts-rs fields", {
+test_that("schema-driven extraction preserves passthrough invariants", {
+  # Whatever nuts-rs emits, the extractor must surface it with the right
+  # shape. We don't pin the exact field set — that's a contract between
+  # nuts-rs and its callers, not nutpieR. We only check generic invariants
+  # over what came through, plus types for the small subset where we're
+  # making a typing promise to users.
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
 
   draws <- nutpie_sample(test_models$bernoulli,
@@ -151,38 +159,37 @@ test_that("schema-driven extraction exposes nuts-rs fields", {
   )
   diag <- nutpie_diagnostics(draws)
 
-  # Fields nuts-rs always emits in sample_stats
-  always_present <- c(
-    "depth", "maxdepth_reached", "index_in_trajectory", "logp", "energy",
-    "chain", "draw", "energy_error", "unconstrained_draw", "gradient",
-    "step_size", "step_size_bar", "mean_tree_accept", "mean_tree_accept_sym",
-    "n_steps", "tuning", "diverging"
+  # Length invariant: every surfaced field is one entry per draw, regardless
+  # of whether it's a scalar vector or a list-of-vectors.
+  n <- posterior::ndraws(draws)
+  for (f in names(diag)) {
+    expect_equal(length(diag[[f]]), n, info = paste("bad length:", f))
+  }
+
+  # Typing promise (matches the roxygen for nutpie_diagnostics): count
+  # fields surface as integer-when-fits, float fields as double, flag
+  # fields as logical. Only enforced for fields that are actually present.
+  type_promise <- list(
+    integer = c("depth", "n_steps", "chain", "draw", "index_in_trajectory"),
+    double  = c("logp", "energy", "step_size", "step_size_bar",
+                "mean_tree_accept"),
+    logical = c("diverging", "tuning", "maxdepth_reached"),
+    list    = c("unconstrained_draw", "gradient")
   )
-  for (f in always_present) {
-    expect_true(f %in% names(diag), info = paste("missing field:", f))
+  for (typ in names(type_promise)) {
+    for (f in intersect(type_promise[[typ]], names(diag))) {
+      expect_type(diag[[f]], typ)
+    }
   }
 
-  # Int*/UInt* columns become R integer when values fit in i32; Float* are
-  # always double. logp is Float64 in the schema, so the integer arm can
-  # never reach it — the silent-truncation trap is structurally avoided.
-  integer_fields <- c("depth", "n_steps", "chain", "draw",
-                      "index_in_trajectory")
-  for (f in integer_fields) {
-    expect_type(diag[[f]], "integer")
+  # Bernoulli has 1 unconstrained parameter, so per-draw vector fields
+  # should be length 1.
+  if ("unconstrained_draw" %in% names(diag)) {
+    expect_equal(length(diag$unconstrained_draw[[1]]), 1)
   }
-  double_fields <- c("logp", "energy", "step_size")
-  for (f in double_fields) {
-    expect_type(diag[[f]], "double")
+  if ("gradient" %in% names(diag)) {
+    expect_equal(length(diag$gradient[[1]]), 1)
   }
-
-  expect_type(diag$maxdepth_reached, "logical")
-  expect_type(diag$tuning, "logical")
-  expect_type(diag$unconstrained_draw, "list")
-  expect_type(diag$gradient, "list")
-
-  # 1-d bernoulli model: each draw's unconstrained_draw / gradient is length 1
-  expect_equal(length(diag$unconstrained_draw[[1]]), 1)
-  expect_equal(length(diag$gradient[[1]]), 1)
 })
 
 test_that("logp is non-zero floating-point — guards silent default-fill", {


### PR DESCRIPTION
## Summary

Replace the hand-maintained per-field copy of `sample_stats` with a schema-driven extractor that walks `nuts-rs`'s Arrow schema and surfaces every column the sampler emits. Resolves #9.

User-visible:
- `nutpie_diagnostics()` returns whatever fields nuts-rs's `sample_stats` schema currently emits — no nutpieR-side allowlist. New nuts-rs diagnostics will appear automatically.
- Count fields (`depth`, `n_steps`, `chain`, `draw`, `index_in_trajectory`) come back as R `integer` when every value fits in `i32`, falling back to `numeric` on overflow. Floats (`logp`, `energy`, `step_size`, etc.) are always `numeric`. So `is.integer(diag$depth)` is now TRUE in the typical case.
- Null Arrow rows surface as proper R NAs (`NA_integer_`, `NA_real_`, `NA`) rather than `NaN` / silently-FALSE. The print method's `sum`/`max`/`mean` aggregations are now NA-safe.

Runtime resilience to schema drift:
- Field added → surfaced.
- Field removed → simply absent.
- Field that is all-null in the requested window (e.g. `mass_matrix_inv` without `store_mass_matrix=TRUE`) → dropped.
- Unknown Arrow dtype → warn-and-skip, rest of extraction continues.

CI signal split into two layers:
- A small `must_have` set (`diverging`, `depth`, `logp`, `energy`, `n_steps`, `step_size_bar`, `mean_tree_accept`) — failing presence/type assertions catch real breakage of fields the package's print method, roxygen, and standard MCMC diagnostics depend on.
- Everything else: passthrough invariants (every field has `length == ndraws`, types match the integer/double/logical/list promise *if present*) — peripheral nuts-rs schema changes don't break nutpieR CI.

## Implementation notes

- `column_to_robj` (Rust): one dispatch arm per Arrow dtype, writing directly into pre-allocated `Doubles`/`Integers`/`Logicals` via the `DerefMut` slice path. The `Int*`/`UInt*` arms do a single fit-check pass over the typed downcast and emit either `Integers` or `Doubles` accordingly.
- LargeList<Float64> path (e.g. `unconstrained_draw`, `gradient`, `mass_matrix_inv`) builds R numeric vectors directly from the Arrow `values()` slice via `Doubles::from_values`, skipping an intermediate `Vec<f64>`.
- `extract_diagnostics` looks up columns by schema index instead of name and builds the named list one-shot via `List::from_pairs`.

## Test plan

- [x] `devtools::test()` — 178 PASS, 2 SKIP (reticulate not installed; one stochastic divergence-detail test).
- [x] posteriordb smoke test against 4 medium-dim models (radon hierarchical 89-d, fims IRT 549-d, seeds 26-d, eight_schools nc 18-d) with `store_mass_matrix = TRUE`. All passed; `radon_mn` exercised the divergence-detail LargeList path (22 surfaced fields including all four `divergence_*`).
- [x] Manual typing spot-check (`is.integer(diag$depth)`, `is.double(diag$logp)`, `is.list(diag$mass_matrix_inv)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)