### PR TITLE
Bump extendr-api to 0.9.0 (closes #7)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.3.0
+Version: 1.3.1
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# nutpieR 1.3.1
+
+* Bumped `extendr-api` from 0.8.1 to 0.9.0. Fixes the R CMD check NOTE
+  about a non-API call to `R_UnboundValue` on R 4.6.0+ (#7) — the symbol
+  was removed from R's public API and from extendr in the 0.9.0 release.
+
 # nutpieR 1.3.0
 
 * `nutpie_sample()`'s `init` as a *partial* named list now fills the missing

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -554,28 +554,30 @@ dependencies = [
 
 [[package]]
 name = "extendr-api"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea54977c6e37236839ffcbc20b5dcea58aa32ae43fbef54a81e1011dc6b19061"
+checksum = "803569de0d273b4bf281871046a7d63a23cc12776bdb5b63de5c1e81aae30728"
 dependencies = [
  "extendr-ffi",
  "extendr-macros",
  "once_cell",
  "paste",
+ "readonly",
 ]
 
 [[package]]
 name = "extendr-ffi"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76777174a82bdb3e66872f580687d3d0143eed1df9b9cd72b321b9596a23ca7"
+checksum = "5ba82ddd48e85202654997b81e4b1d39c0c54b5dcd7cae92705f807bf528efcf"
 
 [[package]]
 name = "extendr-macros"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661cc4ae29de9c4dafe16cfcbda1dbb9f31bd2568f96ebad232cc1f9bcc8b04d"
+checksum = "ba8fad8d2a0d0651b1947042cf3a8beddc73d39cec3485b200fdfd24cb3bb6aa"
 dependencies = [
+ "lazy_static",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -916,6 +918,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1388,6 +1396,17 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "readonly"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a62d85ed81ca5305dc544bd42c8804c5060b78ffa5ad3c64b0fb6a8c13d062"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ 'staticlib' ]
 name = 'nutpieR'
 
 [dependencies]
-extendr-api = '0.8.1'
+extendr-api = '0.9.0'
 nuts-rs = { version = '0.17', features = ['arrow'] }
 anyhow = '1'
 thiserror = '2'

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -6,6 +6,7 @@ use arrow::array::{
 };
 use arrow::datatypes::DataType;
 use extendr_api::prelude::*;
+use extendr_api::error::Result;
 use nuts_rs::{
     ArrowConfig, ArrowTrace, ChainProgress, CpuLogpFunc, CpuMath, DiagGradNutsSettings, HasDims,
     LowRankNutsSettings, Model, ProgressCallback, Sampler, SamplerWaitResult,


### PR DESCRIPTION
## Summary
- Bumps `extendr-api` from 0.8.1 to 0.9.0, fixing the R 4.6.0+ R CMD check NOTE about a non-API call to `R_UnboundValue` (#7). The symbol was removed from R's public API and from extendr in the 0.9.0 release.
- Adds an explicit `use extendr_api::error::Result;` since `Result<T>` is no longer re-exported from `extendr_api::prelude` in 0.9.0.
- Bumps package version 1.3.0 → 1.3.1, NEWS entry added.

## Why this is the whole change
Audited the [v0.9.0 CHANGELOG](https://github.com/extendr/extendr/releases/tag/v0.9.0) against current usage. Other listed breakages (`TryFromRobj` → `TryFromList`, `Scalar` trait removed, `TryFrom<Robj> for &T`) don't affect us. MSRV bumped to 1.71 — well below our declared 1.85. Did not touch the rextendr 0.5.0 scaffold migration; that's separate work.

## Test plan
- [x] `NOT_CRAN=TRUE devtools::install(quick = TRUE)` — clean build (1m 52s release)
- [x] `devtools::test()` — 238 PASS / 0 FAIL / 2 SKIP (same skips as main)
- [x] Verified the `use Result;` line is load-bearing — removing it produces 10 `E0107` errors
- [ ] R-universe build on R 4.6 macOS/windows confirms the `R_UnboundValue` NOTE is gone (will see after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)