### PR TITLE
Adrian feedback (#18 points 2-7): adaptation API, sampler_config, mass-matrix UX (1.7.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.6.0
+Version: 1.7.0
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,10 @@
   are now numeric matrices with shape `(n_draws * n_chains, ndim_unc)`,
   not lists of vectors. Variable-width list columns still fall back to the
   list representation.
+* `mass_matrix_inv` / `mass_matrix_eigvals` / `mass_matrix_stds` rows that
+  fall on a non-update draw now carry the most-recent recorded value
+  forward instead of surfacing `NA` — the inverse mass matrix is
+  piecewise-constant between adapter updates.
 
 # nutpieR 1.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,8 @@
   strategy: `"diag"` (default) or `"low_rank"`. Matches Python nutpie's API.
 * `low_rank_modified_mass_matrix` is soft-deprecated; pass
   `adaptation = "low_rank"` instead.
-* New optional `mindepth` and `max_energy_error` arguments expose the
-  matching `nuts-rs` settings.
+* New optional `mindepth`, `max_energy_error`, and `extra_doublings`
+  arguments expose the matching `nuts-rs` settings.
 * `target_accept`, `max_treedepth`, `mass_matrix_gamma`, and
   `mass_matrix_eigval_cutoff` now default to `NULL` and pass through to
   `nuts-rs`'s defaults when unspecified, instead of overwriting them with

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # nutpieR 1.7.0
 
 * New `adaptation =` argument on `nutpie_sample()` selects the mass-matrix
-  strategy: `"diag"` (default) or `"low_rank"`. Matches Python nutpie's API.
+  strategy: `"diag"` (default) or `"low_rank"` / `"low-rank"`. Matches Python
+  nutpie's API.
 * `low_rank_modified_mass_matrix` is soft-deprecated; pass
   `adaptation = "low_rank"` instead.
 * New optional `mindepth`, `max_energy_error`, and `extra_doublings`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# nutpieR 1.7.0
+
+* New `adaptation =` argument on `nutpie_sample()` selects the mass-matrix
+  strategy: `"diag"` (default) or `"low_rank"`. Matches Python nutpie's API.
+* `low_rank_modified_mass_matrix` is soft-deprecated; pass
+  `adaptation = "low_rank"` instead.
+* New optional `mindepth` and `max_energy_error` arguments expose the
+  matching `nuts-rs` settings.
+* `target_accept`, `max_treedepth`, `mass_matrix_gamma`, and
+  `mass_matrix_eigval_cutoff` now default to `NULL` and pass through to
+  `nuts-rs`'s defaults when unspecified, instead of overwriting them with
+  R-side defaults. Same goes for the previously-bumped 800-warmup default
+  for low-rank.
+* `attr(draws, "sampler_config")` returns the *effective* sampler settings
+  as a JSON string. Parse with `jsonlite::fromJSON()` to inspect what the
+  sampler actually ran with (including any nuts-rs defaults).
+* When `store_mass_matrix = TRUE`, `nutpie_diagnostics(draws)$mass_matrix_inv`
+  (and the matching `unconstrained_draw` / `gradient` columns when stored)
+  are now numeric matrices with shape `(n_draws * n_chains, ndim_unc)`,
+  not lists of vectors. Variable-width list columns still fall back to the
+  list representation.
+
 # nutpieR 1.6.0
 
 * `nutpie_sample()` validates `seed`: `NA`, negative, fractional, and values

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -15,11 +15,16 @@
 #'   (integer when fits in `i32`, else numeric); `logp`, `energy`,
 #'   `energy_error`, `step_size`, `step_size_bar`, `mean_tree_accept`,
 #'   `mean_tree_accept_sym` (numeric).
-#'   List-valued fields (one entry per draw, `NULL` when not recorded):
-#'   `unconstrained_draw`, `gradient`. With `store_mass_matrix = TRUE`:
-#'   `mass_matrix_inv`. With `store_divergences = TRUE`: `divergence_start`,
-#'   `divergence_end`, `divergence_momentum`, `divergence_start_gradient`
-#'   (only present when at least one draw diverged).
+#'   Wide fields (one row per draw, `NA` for unrecorded rows): when
+#'   `store_unconstrained = TRUE`, `unconstrained_draw`; when
+#'   `store_gradient = TRUE`, `gradient`; when `store_mass_matrix = TRUE`,
+#'   `mass_matrix_inv` (and any `mass_matrix_*` columns nuts-rs reports).
+#'   These surface as `(n_draws * n_chains, ndim_unc)` numeric matrices when
+#'   every recorded row has the same width; mixed-width columns fall back
+#'   to a list of numeric vectors (one per draw, `NULL` when not recorded).
+#'   With `store_divergences = TRUE`: `divergence_start`, `divergence_end`,
+#'   `divergence_momentum`, `divergence_start_gradient` (lists, only
+#'   present when at least one draw diverged).
 #' @export
 nutpie_diagnostics <- function(draws) {
   diag <- attr(draws, "diagnostics")

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -15,10 +15,13 @@
 #'   (integer when fits in `i32`, else numeric); `logp`, `energy`,
 #'   `energy_error`, `step_size`, `step_size_bar`, `mean_tree_accept`,
 #'   `mean_tree_accept_sym` (numeric).
-#'   Wide fields (one row per draw, `NA` for unrecorded rows): when
-#'   `store_unconstrained = TRUE`, `unconstrained_draw`; when
-#'   `store_gradient = TRUE`, `gradient`; when `store_mass_matrix = TRUE`,
-#'   `mass_matrix_inv` (and any `mass_matrix_*` columns nuts-rs reports).
+#'   Wide fields (one row per draw): when `store_unconstrained = TRUE`,
+#'   `unconstrained_draw` (`NA` rows where unrecorded); when
+#'   `store_gradient = TRUE`, `gradient` (`NA` rows where unrecorded); when
+#'   `store_mass_matrix = TRUE`, `mass_matrix_inv` (and `mass_matrix_eigvals`
+#'   / `mass_matrix_stds` when reported), with the most recently recorded
+#'   value carried forward into draws between updates — the inverse mass
+#'   matrix is piecewise-constant between adapter steps, not undefined.
 #'   These surface as `(n_draws * n_chains, ndim_unc)` numeric matrices when
 #'   every recorded row has the same width; mixed-width columns fall back
 #'   to a list of numeric vectors (one per draw, `NULL` when not recorded).

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -29,7 +29,7 @@ compile_stan_model <- function(stan_file, stanc_args, compile_args) .Call(wrap__
 #' @param store_mass_matrix Whether to store the mass matrix at each draw.
 #' @param store_unconstrained Whether to store the unconstrained position at each draw.
 #' @param store_gradient Whether to store the gradient at each draw.
-#' @param adaptation One of "diag" or "low_rank".
+#' @param adaptation One of "diag", "low_rank", or "low-rank".
 #' @param max_treedepth Optional maximum tree depth for NUTS. NULL keeps the
 #'   nuts-rs default.
 #' @param mindepth Optional minimum tree depth for NUTS.

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -35,6 +35,8 @@ compile_stan_model <- function(stan_file, stanc_args, compile_args) .Call(wrap__
 #' @param mindepth Optional minimum tree depth for NUTS.
 #' @param target_accept Optional target acceptance probability.
 #' @param max_energy_error Optional energy-error divergence threshold.
+#' @param extra_doublings Optional number of extra tree doublings after a
+#'   turning point is reached.
 #' @param mass_matrix_gamma Optional regularisation parameter for low-rank
 #'   mass matrix.
 #' @param eigval_cutoff Optional eigenvalue cutoff for low-rank mass matrix.
@@ -53,7 +55,7 @@ compile_stan_model <- function(stan_file, stanc_args, compile_args) .Call(wrap__
 #' @return A named list with draws matrix, num_warmup, num_chains, diagnostics,
 #'   sampler_config (JSON), and optionally warmup_draws and warmup_diagnostics.
 #' @noRd
-sample_stan <- function(handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq) .Call(wrap__sample_stan, handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq)
+sample_stan <- function(handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, extra_doublings, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq) .Call(wrap__sample_stan, handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, extra_doublings, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq)
 
 #' Open a BridgeStan model and return an `ExternalPtr<BSHandle>` that caches
 #' parameter-name metadata. The handle may be used by any of the `bs_*`

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -20,8 +20,6 @@ compile_stan_model <- function(stan_file, stanc_args, compile_args) .Call(wrap__
 #' @param num_warmup Number of warmup (tuning) draws per chain.
 #' @param num_chains Number of parallel chains.
 #' @param seed Random seed.
-#' @param max_treedepth Maximum tree depth for NUTS.
-#' @param target_accept Target acceptance probability for step size adaptation.
 #' @param refresh Print progress every `refresh` draws per chain (0 = no progress).
 #' @param init_positions Optional list of numeric vectors (one per chain, or length 1 = broadcast).
 #' @param jitter If TRUE, apply ±0.5 uniform jitter per coordinate.
@@ -31,9 +29,15 @@ compile_stan_model <- function(stan_file, stanc_args, compile_args) .Call(wrap__
 #' @param store_mass_matrix Whether to store the mass matrix at each draw.
 #' @param store_unconstrained Whether to store the unconstrained position at each draw.
 #' @param store_gradient Whether to store the gradient at each draw.
-#' @param low_rank Whether to use low-rank modified mass matrix adaptation.
-#' @param mass_matrix_gamma Regularisation parameter for low-rank mass matrix (default 1e-5).
-#' @param eigval_cutoff Eigenvalue cutoff for low-rank mass matrix (default 2.0).
+#' @param adaptation One of "diag" or "low_rank".
+#' @param max_treedepth Optional maximum tree depth for NUTS. NULL keeps the
+#'   nuts-rs default.
+#' @param mindepth Optional minimum tree depth for NUTS.
+#' @param target_accept Optional target acceptance probability.
+#' @param max_energy_error Optional energy-error divergence threshold.
+#' @param mass_matrix_gamma Optional regularisation parameter for low-rank
+#'   mass matrix.
+#' @param eigval_cutoff Optional eigenvalue cutoff for low-rank mass matrix.
 #' @param keep_indices Optional 0-indexed integer vector of constrained
 #'   parameter columns to materialize. NULL means keep all. Indices are
 #'   resolved against the post-flag column layout selected by
@@ -47,9 +51,9 @@ compile_stan_model <- function(stan_file, stanc_args, compile_args) .Call(wrap__
 #'   (including any `*_rng` calls) entirely. Must imply `include_tp = TRUE`
 #'   when `TRUE`, since GQ may reference TP.
 #' @return A named list with draws matrix, num_warmup, num_chains, diagnostics,
-#'   and optionally warmup_draws and warmup_diagnostics.
+#'   sampler_config (JSON), and optionally warmup_draws and warmup_diagnostics.
 #' @noRd
-sample_stan <- function(handle, num_draws, num_warmup, num_chains, seed, max_treedepth, target_accept, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, low_rank, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq) .Call(wrap__sample_stan, handle, num_draws, num_warmup, num_chains, seed, max_treedepth, target_accept, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, low_rank, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq)
+sample_stan <- function(handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq) .Call(wrap__sample_stan, handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq)
 
 #' Open a BridgeStan model and return an `ExternalPtr<BSHandle>` that caches
 #' parameter-name metadata. The handle may be used by any of the `bs_*`

--- a/R/sample.R
+++ b/R/sample.R
@@ -97,9 +97,9 @@
 #'   \describe{
 #'     \item{`"diag"` (default)}{Diagonal mass matrix (the standard NUTS
 #'       choice).}
-#'     \item{`"low_rank"`}{Low-rank modified mass matrix adaptation. Captures
-#'       posterior correlations and can improve efficiency on models with
-#'       strongly correlated parameters.}
+#'     \item{`"low_rank"` / `"low-rank"`}{Low-rank modified mass matrix
+#'       adaptation. Captures posterior correlations and can improve
+#'       efficiency on models with strongly correlated parameters.}
 #'   }
 #'   Matches the Python nutpie `adaptation=` API. Additional strategies
 #'   (`"draw_diag"`, `"flow"`) may be added in future releases.
@@ -135,7 +135,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
                           store_mass_matrix = FALSE,
                           store_unconstrained = FALSE,
                           store_gradient = FALSE,
-                          adaptation = c("diag", "low_rank"),
+                          adaptation = c("diag", "low_rank", "low-rank"),
                           low_rank_modified_mass_matrix = FALSE,
                           mass_matrix_gamma = NULL,
                           mass_matrix_eigval_cutoff = NULL) {
@@ -147,6 +147,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
     seed <- check_count(seed, "seed", min = 0L, max = .Machine$integer.max)
   }
   adaptation <- match.arg(adaptation)
+  if (identical(adaptation, "low-rank")) adaptation <- "low_rank"
   if (isTRUE(low_rank_modified_mass_matrix)) {
     warning(
       "`low_rank_modified_mass_matrix` is deprecated; use ",

--- a/R/sample.R
+++ b/R/sample.R
@@ -14,8 +14,15 @@
 #' @param num_chains Number of parallel chains.
 #' @param seed Random seed for reproducibility.
 #' @param max_treedepth Maximum tree depth for NUTS. The number of leapfrog
-#'   steps per draw is at most `2^max_treedepth`.
+#'   steps per draw is at most `2^max_treedepth`. Default `NULL` keeps the
+#'   nuts-rs default (currently 10).
+#' @param mindepth Minimum tree depth for NUTS. The number of leapfrog steps
+#'   per draw is at least `2^mindepth`. Default `NULL` keeps the nuts-rs
+#'   default (currently 0).
 #' @param target_accept Target acceptance probability for step size adaptation.
+#'   Default `NULL` keeps the nuts-rs default (currently 0.8).
+#' @param max_energy_error Energy-error threshold above which a leapfrog step
+#'   is treated as a divergence. Default `NULL` keeps the nuts-rs default.
 #' @param refresh How often to print progress updates, in draws per chain.
 #'   Set to `0` to suppress progress output. Default is `100`.
 #' @param init Initial values for each chain. Single entry point that
@@ -83,25 +90,38 @@
 #' @param include Logical (default `TRUE`). If `TRUE`, `pars` specifies the
 #'   parameters to *keep* (whitelist). If `FALSE`, `pars` specifies parameters
 #'   to *exclude* (blacklist). Ignored when `pars` is `NULL`.
-#' @param low_rank_modified_mass_matrix If `TRUE`, use low-rank modified mass
-#'   matrix adaptation. This can improve sampling efficiency for models with
-#'   correlated parameters by capturing posterior correlations in the mass
-#'   matrix. Default is `FALSE` (diagonal mass matrix).
+#' @param adaptation Mass matrix adaptation strategy. One of:
+#'   \describe{
+#'     \item{`"diag"` (default)}{Diagonal mass matrix (the standard NUTS
+#'       choice).}
+#'     \item{`"low_rank"`}{Low-rank modified mass matrix adaptation. Captures
+#'       posterior correlations and can improve efficiency on models with
+#'       strongly correlated parameters.}
+#'   }
+#'   Matches the Python nutpie `adaptation=` API. Additional strategies
+#'   (`"draw_diag"`, `"flow"`) may be added in future releases.
+#' @param low_rank_modified_mass_matrix Deprecated. If `TRUE`, equivalent to
+#'   `adaptation = "low_rank"`. Will be removed in a future release.
 #' @param mass_matrix_gamma Regularisation parameter for low-rank mass matrix
-#'   adaptation. Only used when `low_rank_modified_mass_matrix = TRUE`.
-#'   Default is `1e-5`.
+#'   adaptation. Only used when `adaptation = "low_rank"`; ignored otherwise.
+#'   Default `NULL` keeps the nuts-rs default (currently `1e-5`).
 #' @param mass_matrix_eigval_cutoff Eigenvalue cutoff for low-rank mass matrix.
 #'   Eigenvalues outside `(1/cutoff, cutoff)` are ignored. Only used when
-#'   `low_rank_modified_mass_matrix = TRUE`. Default is `2.0`.
+#'   `adaptation = "low_rank"`; ignored otherwise. Default `NULL` keeps the
+#'   nuts-rs default (currently `2.0`).
 #' @return A `posterior::draws_array` with dimensions
 #'   `(num_draws, num_chains, n_params)`. Sampler diagnostics are attached
 #'   as an attribute and can be retrieved with [nutpie_diagnostics()].
 #'   The attributes `"num_warmup"` and `"num_draws"` record the sampling
-#'   configuration (accessible via `attr(draws, "num_warmup")` etc.).
+#'   configuration (accessible via `attr(draws, "num_warmup")` etc.). The
+#'   `"sampler_config"` attribute is a JSON string capturing the *effective*
+#'   `nuts-rs` settings used (including any defaults that were left
+#'   unspecified by the caller); parse with [jsonlite::fromJSON()].
 #' @export
 nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
                           num_warmup = 400L, num_chains = 4L, seed = NULL,
-                          max_treedepth = 10L, target_accept = 0.8,
+                          max_treedepth = NULL, mindepth = NULL,
+                          target_accept = NULL, max_energy_error = NULL,
                           refresh = 100L,
                           init = NULL,
                           init_mean = NULL,
@@ -111,9 +131,10 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
                           store_mass_matrix = FALSE,
                           store_unconstrained = FALSE,
                           store_gradient = FALSE,
+                          adaptation = c("diag", "low_rank"),
                           low_rank_modified_mass_matrix = FALSE,
-                          mass_matrix_gamma = 1e-5,
-                          mass_matrix_eigval_cutoff = 2.0) {
+                          mass_matrix_gamma = NULL,
+                          mass_matrix_eigval_cutoff = NULL) {
   lib_path <- resolve_model(model)
   data_json <- resolve_data(data)
   if (is.null(seed)) {
@@ -121,21 +142,19 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   } else {
     seed <- check_count(seed, "seed", min = 0L, max = .Machine$integer.max)
   }
-  # Low-rank mass matrix needs more warmup for the off-diagonal structure to
-  # stabilise. Bump the default to 800 (matches Python nutpie); explicit
-  # user-supplied values win.
-  if (missing(num_warmup) && isTRUE(low_rank_modified_mass_matrix)) {
-    num_warmup <- 800L
+  adaptation <- match.arg(adaptation)
+  if (isTRUE(low_rank_modified_mass_matrix)) {
+    warning(
+      "`low_rank_modified_mass_matrix` is deprecated; use ",
+      "`adaptation = \"low_rank\"` instead. ",
+      "`low_rank_modified_mass_matrix` will be removed in a future version.",
+      call. = FALSE
+    )
+    adaptation <- "low_rank"
   }
   num_draws <- check_count(num_draws, "num_draws", min = 1L)
   num_warmup <- check_count(num_warmup, "num_warmup", min = 0L)
   num_chains <- check_count(num_chains, "num_chains", min = 1L)
-  max_treedepth <- check_count(max_treedepth, "max_treedepth", min = 1L)
-  if (!is.numeric(target_accept) || length(target_accept) != 1L ||
-      !is.finite(target_accept) || target_accept <= 0 || target_accept >= 1) {
-    stop("`target_accept` must be a single finite value in (0, 1).",
-         call. = FALSE)
-  }
 
   if (is.null(cores)) {
     cores <- min(num_chains, parallel::detectCores())
@@ -158,8 +177,6 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
     num_warmup,
     num_chains,
     as.integer(seed),
-    as.integer(max_treedepth),
-    as.double(target_accept),
     as.integer(refresh),
     init_resolved$positions,
     isTRUE(init_resolved$jitter),
@@ -169,9 +186,13 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
     isTRUE(store_mass_matrix),
     isTRUE(store_unconstrained),
     isTRUE(store_gradient),
-    isTRUE(low_rank_modified_mass_matrix),
-    as.double(mass_matrix_gamma),
-    as.double(mass_matrix_eigval_cutoff),
+    adaptation,
+    opt_double(max_treedepth),
+    opt_double(mindepth),
+    opt_double(target_accept),
+    opt_double(max_energy_error),
+    opt_double(mass_matrix_gamma),
+    opt_double(mass_matrix_eigval_cutoff),
     keep_indices,
     isTRUE(flags$include_tp),
     isTRUE(flags$include_gq)
@@ -181,6 +202,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   attr(draws, "num_chains") <- num_chains
   attr(draws, "num_warmup") <- num_warmup
   attr(draws, "num_draws") <- num_draws
+  attr(draws, "sampler_config") <- raw$sampler_config
 
   if (isTRUE(save_warmup) && !is.null(raw$warmup_draws)) {
     warmup <- matrix_to_draws_array(raw$warmup_draws, num_warmup, num_chains)
@@ -201,6 +223,8 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
 
   draws
 }
+
+opt_double <- function(x) if (is.null(x)) NULL else as.double(x)
 
 check_count <- function(x, name, min = 0L, max = NULL) {
   if (length(x) != 1L) {

--- a/R/sample.R
+++ b/R/sample.R
@@ -23,6 +23,9 @@
 #'   Default `NULL` keeps the nuts-rs default (currently 0.8).
 #' @param max_energy_error Energy-error threshold above which a leapfrog step
 #'   is treated as a divergence. Default `NULL` keeps the nuts-rs default.
+#' @param extra_doublings Number of additional tree doublings allowed after a
+#'   turning point is reached. Default `NULL` keeps the nuts-rs default
+#'   (currently 0).
 #' @param refresh How often to print progress updates, in draws per chain.
 #'   Set to `0` to suppress progress output. Default is `100`.
 #' @param init Initial values for each chain. Single entry point that
@@ -122,6 +125,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
                           num_warmup = 400L, num_chains = 4L, seed = NULL,
                           max_treedepth = NULL, mindepth = NULL,
                           target_accept = NULL, max_energy_error = NULL,
+                          extra_doublings = NULL,
                           refresh = 100L,
                           init = NULL,
                           init_mean = NULL,
@@ -191,6 +195,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
     opt_double(mindepth, "mindepth"),
     opt_double(target_accept, "target_accept"),
     opt_double(max_energy_error, "max_energy_error"),
+    opt_double(extra_doublings, "extra_doublings"),
     opt_double(mass_matrix_gamma, "mass_matrix_gamma"),
     opt_double(mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"),
     keep_indices,

--- a/R/sample.R
+++ b/R/sample.R
@@ -187,12 +187,12 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
     isTRUE(store_unconstrained),
     isTRUE(store_gradient),
     adaptation,
-    opt_double(max_treedepth),
-    opt_double(mindepth),
-    opt_double(target_accept),
-    opt_double(max_energy_error),
-    opt_double(mass_matrix_gamma),
-    opt_double(mass_matrix_eigval_cutoff),
+    opt_double(max_treedepth, "max_treedepth"),
+    opt_double(mindepth, "mindepth"),
+    opt_double(target_accept, "target_accept"),
+    opt_double(max_energy_error, "max_energy_error"),
+    opt_double(mass_matrix_gamma, "mass_matrix_gamma"),
+    opt_double(mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"),
     keep_indices,
     isTRUE(flags$include_tp),
     isTRUE(flags$include_gq)
@@ -224,7 +224,14 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   draws
 }
 
-opt_double <- function(x) if (is.null(x)) NULL else as.double(x)
+opt_double <- function(x, name) {
+  if (is.null(x)) return(NULL)
+  if (!is.numeric(x) || length(x) != 1L || !is.finite(x)) {
+    stop(sprintf("`%s` must be NULL or a single finite number.", name),
+         call. = FALSE)
+  }
+  as.double(x)
+}
 
 check_count <- function(x, name, min = 0L, max = NULL) {
   if (length(x) != 1L) {

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ R is not in the hot loop -- parallel chains run entirely in Rust.
 Precompiled binaries are available from R-universe (no Rust toolchain needed):
 
 ```r
-install.packages("nutpieR", repos = "https://andytimm.r-universe.dev")
+install.packages("nutpieR",
+  repos = c("https://andytimm.r-universe.dev", "https://cloud.r-project.org"))
 ```
+
+(CRAN is included so the imports — `digest`, `jsonlite`, `posterior` — resolve;
+the andytimm.r-universe.dev repo only hosts `nutpieR` itself.)
 
 Or install from source (requires a [Rust toolchain](https://rustup.rs/)):
 

--- a/man/nutpie_diagnostics.Rd
+++ b/man/nutpie_diagnostics.Rd
@@ -16,10 +16,13 @@ Commonly available scalar fields: \code{diverging}, \code{tuning}, \code{maxdept
 (integer when fits in \code{i32}, else numeric); \code{logp}, \code{energy},
 \code{energy_error}, \code{step_size}, \code{step_size_bar}, \code{mean_tree_accept},
 \code{mean_tree_accept_sym} (numeric).
-Wide fields (one row per draw, \code{NA} for unrecorded rows): when
-\code{store_unconstrained = TRUE}, \code{unconstrained_draw}; when
-\code{store_gradient = TRUE}, \code{gradient}; when \code{store_mass_matrix = TRUE},
-\code{mass_matrix_inv} (and any \verb{mass_matrix_*} columns nuts-rs reports).
+Wide fields (one row per draw): when \code{store_unconstrained = TRUE},
+\code{unconstrained_draw} (\code{NA} rows where unrecorded); when
+\code{store_gradient = TRUE}, \code{gradient} (\code{NA} rows where unrecorded); when
+\code{store_mass_matrix = TRUE}, \code{mass_matrix_inv} (and \code{mass_matrix_eigvals}
+/ \code{mass_matrix_stds} when reported), with the most recently recorded
+value carried forward into draws between updates — the inverse mass
+matrix is piecewise-constant between adapter steps, not undefined.
 These surface as \verb{(n_draws * n_chains, ndim_unc)} numeric matrices when
 every recorded row has the same width; mixed-width columns fall back
 to a list of numeric vectors (one per draw, \code{NULL} when not recorded).

--- a/man/nutpie_diagnostics.Rd
+++ b/man/nutpie_diagnostics.Rd
@@ -16,11 +16,16 @@ Commonly available scalar fields: \code{diverging}, \code{tuning}, \code{maxdept
 (integer when fits in \code{i32}, else numeric); \code{logp}, \code{energy},
 \code{energy_error}, \code{step_size}, \code{step_size_bar}, \code{mean_tree_accept},
 \code{mean_tree_accept_sym} (numeric).
-List-valued fields (one entry per draw, \code{NULL} when not recorded):
-\code{unconstrained_draw}, \code{gradient}. With \code{store_mass_matrix = TRUE}:
-\code{mass_matrix_inv}. With \code{store_divergences = TRUE}: \code{divergence_start},
-\code{divergence_end}, \code{divergence_momentum}, \code{divergence_start_gradient}
-(only present when at least one draw diverged).
+Wide fields (one row per draw, \code{NA} for unrecorded rows): when
+\code{store_unconstrained = TRUE}, \code{unconstrained_draw}; when
+\code{store_gradient = TRUE}, \code{gradient}; when \code{store_mass_matrix = TRUE},
+\code{mass_matrix_inv} (and any \verb{mass_matrix_*} columns nuts-rs reports).
+These surface as \verb{(n_draws * n_chains, ndim_unc)} numeric matrices when
+every recorded row has the same width; mixed-width columns fall back
+to a list of numeric vectors (one per draw, \code{NULL} when not recorded).
+With \code{store_divergences = TRUE}: \code{divergence_start}, \code{divergence_end},
+\code{divergence_momentum}, \code{divergence_start_gradient} (lists, only
+present when at least one draw diverged).
 }
 \description{
 Diagnostics are extracted directly from the nuts-rs sample-stats schema, so

--- a/man/nutpie_sample.Rd
+++ b/man/nutpie_sample.Rd
@@ -11,8 +11,10 @@ nutpie_sample(
   num_warmup = 400L,
   num_chains = 4L,
   seed = NULL,
-  max_treedepth = 10L,
-  target_accept = 0.8,
+  max_treedepth = NULL,
+  mindepth = NULL,
+  target_accept = NULL,
+  max_energy_error = NULL,
   refresh = 100L,
   init = NULL,
   init_mean = NULL,
@@ -24,9 +26,10 @@ nutpie_sample(
   store_mass_matrix = FALSE,
   store_unconstrained = FALSE,
   store_gradient = FALSE,
+  adaptation = c("diag", "low_rank"),
   low_rank_modified_mass_matrix = FALSE,
-  mass_matrix_gamma = 1e-05,
-  mass_matrix_eigval_cutoff = 2
+  mass_matrix_gamma = NULL,
+  mass_matrix_eigval_cutoff = NULL
 )
 }
 \arguments{
@@ -50,9 +53,18 @@ or a path to a compiled shared library.}
 \item{seed}{Random seed for reproducibility.}
 
 \item{max_treedepth}{Maximum tree depth for NUTS. The number of leapfrog
-steps per draw is at most \code{2^max_treedepth}.}
+steps per draw is at most \code{2^max_treedepth}. Default \code{NULL} keeps the
+nuts-rs default (currently 10).}
 
-\item{target_accept}{Target acceptance probability for step size adaptation.}
+\item{mindepth}{Minimum tree depth for NUTS. The number of leapfrog steps
+per draw is at least \code{2^mindepth}. Default \code{NULL} keeps the nuts-rs
+default (currently 0).}
+
+\item{target_accept}{Target acceptance probability for step size adaptation.
+Default \code{NULL} keeps the nuts-rs default (currently 0.8).}
+
+\item{max_energy_error}{Energy-error threshold above which a leapfrog step
+is treated as a divergence. Default \code{NULL} keeps the nuts-rs default.}
 
 \item{refresh}{How often to print progress updates, in draws per chain.
 Set to \code{0} to suppress progress output. Default is \code{100}.}
@@ -132,25 +144,38 @@ models this can rival the draws matrix in size. Default \code{FALSE}.}
 draw as a list column on diagnostics (\code{gradient}). Same size profile as
 \code{store_unconstrained}. Default \code{FALSE}.}
 
-\item{low_rank_modified_mass_matrix}{If \code{TRUE}, use low-rank modified mass
-matrix adaptation. This can improve sampling efficiency for models with
-correlated parameters by capturing posterior correlations in the mass
-matrix. Default is \code{FALSE} (diagonal mass matrix).}
+\item{adaptation}{Mass matrix adaptation strategy. One of:
+\describe{
+\item{\code{"diag"} (default)}{Diagonal mass matrix (the standard NUTS
+choice).}
+\item{\code{"low_rank"}}{Low-rank modified mass matrix adaptation. Captures
+posterior correlations and can improve efficiency on models with
+strongly correlated parameters.}
+}
+Matches the Python nutpie \verb{adaptation=} API. Additional strategies
+(\code{"draw_diag"}, \code{"flow"}) may be added in future releases.}
+
+\item{low_rank_modified_mass_matrix}{Deprecated. If \code{TRUE}, equivalent to
+\code{adaptation = "low_rank"}. Will be removed in a future release.}
 
 \item{mass_matrix_gamma}{Regularisation parameter for low-rank mass matrix
-adaptation. Only used when \code{low_rank_modified_mass_matrix = TRUE}.
-Default is \code{1e-5}.}
+adaptation. Only used when \code{adaptation = "low_rank"}; ignored otherwise.
+Default \code{NULL} keeps the nuts-rs default (currently \code{1e-5}).}
 
 \item{mass_matrix_eigval_cutoff}{Eigenvalue cutoff for low-rank mass matrix.
 Eigenvalues outside \verb{(1/cutoff, cutoff)} are ignored. Only used when
-\code{low_rank_modified_mass_matrix = TRUE}. Default is \code{2.0}.}
+\code{adaptation = "low_rank"}; ignored otherwise. Default \code{NULL} keeps the
+nuts-rs default (currently \code{2.0}).}
 }
 \value{
 A \code{posterior::draws_array} with dimensions
 \verb{(num_draws, num_chains, n_params)}. Sampler diagnostics are attached
 as an attribute and can be retrieved with \code{\link[=nutpie_diagnostics]{nutpie_diagnostics()}}.
 The attributes \code{"num_warmup"} and \code{"num_draws"} record the sampling
-configuration (accessible via \code{attr(draws, "num_warmup")} etc.).
+configuration (accessible via \code{attr(draws, "num_warmup")} etc.). The
+\code{"sampler_config"} attribute is a JSON string capturing the \emph{effective}
+\code{nuts-rs} settings used (including any defaults that were left
+unspecified by the caller); parse with \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}.
 }
 \description{
 Runs the nuts-rs NUTS sampler on a compiled Stan model.

--- a/man/nutpie_sample.Rd
+++ b/man/nutpie_sample.Rd
@@ -15,6 +15,7 @@ nutpie_sample(
   mindepth = NULL,
   target_accept = NULL,
   max_energy_error = NULL,
+  extra_doublings = NULL,
   refresh = 100L,
   init = NULL,
   init_mean = NULL,
@@ -65,6 +66,10 @@ Default \code{NULL} keeps the nuts-rs default (currently 0.8).}
 
 \item{max_energy_error}{Energy-error threshold above which a leapfrog step
 is treated as a divergence. Default \code{NULL} keeps the nuts-rs default.}
+
+\item{extra_doublings}{Number of additional tree doublings allowed after a
+turning point is reached. Default \code{NULL} keeps the nuts-rs default
+(currently 0).}
 
 \item{refresh}{How often to print progress updates, in draws per chain.
 Set to \code{0} to suppress progress output. Default is \code{100}.}

--- a/man/nutpie_sample.Rd
+++ b/man/nutpie_sample.Rd
@@ -27,7 +27,7 @@ nutpie_sample(
   store_mass_matrix = FALSE,
   store_unconstrained = FALSE,
   store_gradient = FALSE,
-  adaptation = c("diag", "low_rank"),
+  adaptation = c("diag", "low_rank", "low-rank"),
   low_rank_modified_mass_matrix = FALSE,
   mass_matrix_gamma = NULL,
   mass_matrix_eigval_cutoff = NULL
@@ -153,9 +153,9 @@ draw as a list column on diagnostics (\code{gradient}). Same size profile as
 \describe{
 \item{\code{"diag"} (default)}{Diagonal mass matrix (the standard NUTS
 choice).}
-\item{\code{"low_rank"}}{Low-rank modified mass matrix adaptation. Captures
-posterior correlations and can improve efficiency on models with
-strongly correlated parameters.}
+\item{\code{"low_rank"} / \code{"low-rank"}}{Low-rank modified mass matrix
+adaptation. Captures posterior correlations and can improve
+efficiency on models with strongly correlated parameters.}
 }
 Matches the Python nutpie \verb{adaptation=} API. Additional strategies
 (\code{"draw_diag"}, \code{"flow"}) may be added in future releases.}

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "607e64bb911ee4f90483e044fe78f175989148c2892e659a2cd25429e782ec54"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "e754319ed8a85d817fe7adf183227e0b5308b82790a737b426c1124626b48118"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -93,7 +93,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
 dependencies = [
  "bytes",
  "half",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "ca5e686972523798f76bef355145bc1ae25a84c731e650268d31ab763c701663"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
+checksum = "86c276756867fc8186ec380c72c290e6e3b23a1d4fb05df6b1d62d2e62666d48"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "fd8907ddd8f9fbabf91ec2c85c1d81fe2874e336d2443eb36373595e28b98dd5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -176,15 +176,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "f4518c59acc501f10d7dcae397fe12b8db3d81bc7de94456f8a58f9165d6f502"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
@@ -200,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -213,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "faec88a945338192beffbbd4be0def70135422930caa244ac3cec0cd213b26b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -226,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
 dependencies = [
  "serde_core",
  "serde_json",
@@ -236,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -250,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "f6de2efbbd1a9f9780ceb8d1ff5d20421b35863b361e3386b4f571f1fc69fcb8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -796,11 +797,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -829,6 +832,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1177,11 +1186,11 @@ dependencies = [
 
 [[package]]
 name = "nuts-derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64eac5046c75ced9bdaede15ebc30c4ce982a13e75032ae8d5c1312d1e05d82e"
+checksum = "a8cce587b5f36bc6bfa54cbf2eaf31fe5a5e0d73e96d31fde5de87a701689363"
 dependencies = [
- "nuts-storable 0.1.0",
+ "nuts-storable",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1189,17 +1198,18 @@ dependencies = [
 
 [[package]]
 name = "nuts-rs"
-version = "0.17.4"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd441b25a4ff7c222e396d073f36ec03ab3be4264a59a81264bd4501616df31"
+checksum = "a62664bb4327ef957a2188e2ea314d6693261100b9c2cc68c1b2398da301f6e2"
 dependencies = [
  "anyhow",
  "arrow",
  "arrow-schema",
  "faer",
+ "getrandom 0.4.2",
  "itertools",
  "nuts-derive",
- "nuts-storable 0.2.0",
+ "nuts-storable",
  "pulp",
  "rand",
  "rand_distr",
@@ -1211,15 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "nuts-storable"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6cf9fc84ca313648ddb112f8728eb2f9531f2e4533959dd01127eb34290b5b"
-
-[[package]]
-name = "nuts-storable"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdee8fb53ac39f042885e732348a5bce2f28a08adc2798314a3c66a5f199293"
+checksum = "a9257959045c9682c06b3f993215f1b2896bf276a1fcf39f83ac0755a904dc0d"
 
 [[package]]
 name = "once_cell"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "extendr-api",
  "nuts-rs",
  "rand",
+ "serde_json",
  "thiserror",
 ]
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "extendr-api",
  "nuts-rs",
  "rand",
+ "serde",
  "serde_json",
  "thiserror",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,6 +18,7 @@ rand = '0.10'
 arrow = { version = '57', default-features = false }
 bridgestan = { version = '2.7', features = ['download-bridgestan-src'] }
 dirs = '6'
+serde_json = '1'
 
 [patch.crates-io]
 # Patch bridgestan to add allowlist filters in build.rs.

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -11,11 +11,11 @@ name = 'nutpieR'
 
 [dependencies]
 extendr-api = '0.9.0'
-nuts-rs = { version = '0.17', features = ['arrow'] }
+nuts-rs = { version = '0.18', features = ['arrow'] }
 anyhow = '1'
 thiserror = '2'
 rand = '0.10'
-arrow = { version = '57', default-features = false }
+arrow = { version = '58', default-features = false }
 bridgestan = { version = '2.7', features = ['download-bridgestan-src'] }
 dirs = '6'
 serde = '1'

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,6 +18,7 @@ rand = '0.10'
 arrow = { version = '57', default-features = false }
 bridgestan = { version = '2.7', features = ['download-bridgestan-src'] }
 dirs = '6'
+serde = '1'
 serde_json = '1'
 
 [patch.crates-io]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -219,8 +219,6 @@ fn run_sampler<S: Settings>(
 /// @param num_warmup Number of warmup (tuning) draws per chain.
 /// @param num_chains Number of parallel chains.
 /// @param seed Random seed.
-/// @param max_treedepth Maximum tree depth for NUTS.
-/// @param target_accept Target acceptance probability for step size adaptation.
 /// @param refresh Print progress every `refresh` draws per chain (0 = no progress).
 /// @param init_positions Optional list of numeric vectors (one per chain, or length 1 = broadcast).
 /// @param jitter If TRUE, apply ±0.5 uniform jitter per coordinate.
@@ -230,9 +228,15 @@ fn run_sampler<S: Settings>(
 /// @param store_mass_matrix Whether to store the mass matrix at each draw.
 /// @param store_unconstrained Whether to store the unconstrained position at each draw.
 /// @param store_gradient Whether to store the gradient at each draw.
-/// @param low_rank Whether to use low-rank modified mass matrix adaptation.
-/// @param mass_matrix_gamma Regularisation parameter for low-rank mass matrix (default 1e-5).
-/// @param eigval_cutoff Eigenvalue cutoff for low-rank mass matrix (default 2.0).
+/// @param adaptation One of "diag" or "low_rank".
+/// @param max_treedepth Optional maximum tree depth for NUTS. NULL keeps the
+///   nuts-rs default.
+/// @param mindepth Optional minimum tree depth for NUTS.
+/// @param target_accept Optional target acceptance probability.
+/// @param max_energy_error Optional energy-error divergence threshold.
+/// @param mass_matrix_gamma Optional regularisation parameter for low-rank
+///   mass matrix.
+/// @param eigval_cutoff Optional eigenvalue cutoff for low-rank mass matrix.
 /// @param keep_indices Optional 0-indexed integer vector of constrained
 ///   parameter columns to materialize. NULL means keep all. Indices are
 ///   resolved against the post-flag column layout selected by
@@ -246,7 +250,7 @@ fn run_sampler<S: Settings>(
 ///   (including any `*_rng` calls) entirely. Must imply `include_tp = TRUE`
 ///   when `TRUE`, since GQ may reference TP.
 /// @return A named list with draws matrix, num_warmup, num_chains, diagnostics,
-///   and optionally warmup_draws and warmup_diagnostics.
+///   sampler_config (JSON), and optionally warmup_draws and warmup_diagnostics.
 /// @noRd
 #[extendr]
 fn sample_stan(
@@ -255,8 +259,6 @@ fn sample_stan(
     num_warmup: i32,
     num_chains: i32,
     seed: i32,
-    max_treedepth: i32,
-    target_accept: f64,
     refresh: i32,
     init_positions: Robj,
     jitter: bool,
@@ -266,9 +268,13 @@ fn sample_stan(
     store_mass_matrix: bool,
     store_unconstrained: bool,
     store_gradient: bool,
-    low_rank: bool,
-    mass_matrix_gamma: f64,
-    eigval_cutoff: f64,
+    adaptation: &str,
+    max_treedepth: Robj,
+    mindepth: Robj,
+    target_accept: Robj,
+    max_energy_error: Robj,
+    mass_matrix_gamma: Robj,
+    eigval_cutoff: Robj,
     keep_indices: Robj,
     include_tp: bool,
     include_gq: bool,
@@ -281,7 +287,6 @@ fn sample_stan(
     for (val, name) in [
         (num_draws, "num_draws"),
         (num_chains, "num_chains"),
-        (max_treedepth, "max_treedepth"),
         (num_cores, "num_cores"),
     ] {
         if val <= 0 {
@@ -298,11 +303,46 @@ fn sample_stan(
         )));
     }
     check_seed(seed)?;
-    if !(target_accept > 0.0 && target_accept < 1.0) {
-        return Err(Error::Other(format!(
-            "target_accept must be in (0, 1), got {}",
-            target_accept
-        )));
+
+    // Optional config knobs. NULL on the R side leaves the nuts-rs default
+    // in place — we don't second-guess upstream tuning choices.
+    let max_treedepth_opt = opt_count(&max_treedepth, "max_treedepth", 1)?;
+    let mindepth_opt = opt_count(&mindepth, "mindepth", 0)?;
+    let target_accept_opt = opt_finite_f64(&target_accept, "target_accept")?;
+    if let Some(v) = target_accept_opt {
+        if !(v > 0.0 && v < 1.0) {
+            return Err(Error::Other(format!(
+                "target_accept must be in (0, 1), got {}",
+                v
+            )));
+        }
+    }
+    let max_energy_error_opt = opt_finite_f64(&max_energy_error, "max_energy_error")?;
+    if let Some(v) = max_energy_error_opt {
+        if !(v > 0.0) {
+            return Err(Error::Other(format!(
+                "max_energy_error must be > 0, got {}",
+                v
+            )));
+        }
+    }
+    let mass_matrix_gamma_opt = opt_finite_f64(&mass_matrix_gamma, "mass_matrix_gamma")?;
+    if let Some(v) = mass_matrix_gamma_opt {
+        if !(v > 0.0) {
+            return Err(Error::Other(format!(
+                "mass_matrix_gamma must be > 0, got {}",
+                v
+            )));
+        }
+    }
+    let eigval_cutoff_opt = opt_finite_f64(&eigval_cutoff, "eigval_cutoff")?;
+    if let Some(v) = eigval_cutoff_opt {
+        if !(v > 0.0) {
+            return Err(Error::Other(format!(
+                "eigval_cutoff must be > 0, got {}",
+                v
+            )));
+        }
     }
 
     let init_positions_raw: Option<Vec<Vec<f64>>> = if init_positions.is_null() {
@@ -365,8 +405,18 @@ fn sample_stan(
             $settings.num_draws = num_draws as u64;
             $settings.num_chains = num_chains as usize;
             $settings.seed = seed as u64;
-            $settings.maxdepth = max_treedepth as u64;
-            $settings.adapt_options.step_size_settings.target_accept = target_accept;
+            if let Some(v) = max_treedepth_opt {
+                $settings.maxdepth = v as u64;
+            }
+            if let Some(v) = mindepth_opt {
+                $settings.mindepth = v as u64;
+            }
+            if let Some(v) = target_accept_opt {
+                $settings.adapt_options.step_size_settings.target_accept = v;
+            }
+            if let Some(v) = max_energy_error_opt {
+                $settings.max_energy_error = v;
+            }
             $settings.store_divergences = store_divergences;
             $settings.store_unconstrained = store_unconstrained;
             $settings.store_gradient = store_gradient;
@@ -374,16 +424,35 @@ fn sample_stan(
         }};
     }
 
-    let results = if low_rank {
-        let mut settings = LowRankNutsSettings::default();
-        configure_settings!(settings);
-        settings.adapt_options.mass_matrix_options.gamma = mass_matrix_gamma;
-        settings.adapt_options.mass_matrix_options.eigval_cutoff = eigval_cutoff;
-        run_sampler(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?
-    } else {
-        let mut settings = DiagGradNutsSettings::default();
-        configure_settings!(settings);
-        run_sampler(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?
+    let (results, sampler_config_json) = match adaptation {
+        "low_rank" => {
+            let mut settings = LowRankNutsSettings::default();
+            configure_settings!(settings);
+            if let Some(v) = mass_matrix_gamma_opt {
+                settings.adapt_options.mass_matrix_options.gamma = v;
+            }
+            if let Some(v) = eigval_cutoff_opt {
+                settings.adapt_options.mass_matrix_options.eigval_cutoff = v;
+            }
+            let json = serde_json::to_string(&settings)
+                .map_err(|e| Error::Other(format!("failed to serialize sampler settings: {}", e)))?;
+            let r = run_sampler(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?;
+            (r, json)
+        }
+        "diag" => {
+            let mut settings = DiagGradNutsSettings::default();
+            configure_settings!(settings);
+            let json = serde_json::to_string(&settings)
+                .map_err(|e| Error::Other(format!("failed to serialize sampler settings: {}", e)))?;
+            let r = run_sampler(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?;
+            (r, json)
+        }
+        other => {
+            return Err(Error::Other(format!(
+                "adaptation must be one of \"diag\" or \"low_rank\", got \"{}\"",
+                other
+            )));
+        }
     };
 
     let draws_robj = build_draws_matrix(
@@ -433,9 +502,57 @@ fn sample_stan(
         diagnostics = diagnostics,
         warmup_draws = warmup_draws_robj,
         warmup_diagnostics = warmup_diagnostics_robj,
-        expand_errors = n_expand_errors
+        expand_errors = n_expand_errors,
+        sampler_config = sampler_config_json
     ))
     })())
+}
+
+/// Coerce an optional R scalar (`NULL`, integer, or numeric) to `Option<i32>`.
+/// Validates finiteness, integral-ness, and a `>= min` bound. Used by the
+/// FFI for sampler config knobs that should only override the nuts-rs
+/// default when the R caller explicitly passes a value.
+fn opt_count(robj: &Robj, name: &str, min: i32) -> Result<Option<i32>> {
+    if robj.is_null() {
+        return Ok(None);
+    }
+    let v: f64 = robj
+        .as_real()
+        .ok_or_else(|| Error::Other(format!("`{}` must be NULL or a single numeric.", name)))?;
+    if !v.is_finite() {
+        return Err(Error::Other(format!("`{}` must be a finite integer.", name)));
+    }
+    if v.fract() != 0.0 {
+        return Err(Error::Other(format!(
+            "`{}` must be a whole number, got {}.",
+            name, v
+        )));
+    }
+    if v < min as f64 || v > i32::MAX as f64 {
+        return Err(Error::Other(format!(
+            "`{}` must be in [{}, {}], got {}.",
+            name,
+            min,
+            i32::MAX,
+            v
+        )));
+    }
+    Ok(Some(v as i32))
+}
+
+/// Coerce an optional R scalar (`NULL` or numeric) to `Option<f64>`.
+/// Validates finiteness only — caller does range checks.
+fn opt_finite_f64(robj: &Robj, name: &str) -> Result<Option<f64>> {
+    if robj.is_null() {
+        return Ok(None);
+    }
+    let v: f64 = robj
+        .as_real()
+        .ok_or_else(|| Error::Other(format!("`{}` must be NULL or a single numeric.", name)))?;
+    if !v.is_finite() {
+        return Err(Error::Other(format!("`{}` must be a finite number.", name)));
+    }
+    Ok(Some(v))
 }
 
 /// Build a draws matrix from Arrow traces.
@@ -602,16 +719,87 @@ fn column_to_robj(
         DataType::Int32 => build_int_or_double!(Int32Array, |v: i32| v > i32::MIN),
         DataType::UInt32 => build_int_or_double!(UInt32Array, |v: u32| v <= i32::MAX as u32),
         DataType::LargeList(inner) if matches!(inner.data_type(), DataType::Float64) => {
-            let mut out: Vec<Robj> = Vec::with_capacity(total);
-            for c in cols {
-                let list_arr = c.as_any().downcast_ref::<LargeListArray>()?;
+            // First pass: collect downcasted handles, check whether every
+            // non-null row in the requested window has the same inner length.
+            // If so (e.g. `mass_matrix_inv`, `mass_matrix_eigvals`,
+            // `mass_matrix_stds`, all `ndim_unc` wide), surface a 2-D
+            // `(total, inner_len)` matrix instead of a list-of-vectors —
+            // much friendlier downstream.
+            let arrs: Vec<&LargeListArray> = cols
+                .iter()
+                .map(|c| c.as_any().downcast_ref::<LargeListArray>())
+                .collect::<Option<Vec<_>>>()?;
+
+            let mut uniform_len: Option<usize> = None;
+            let mut mixed = false;
+            'outer: for arr in &arrs {
                 for k in 0..n_draws {
                     let row = skip + k;
-                    if list_arr.is_null(row) {
+                    if arr.is_null(row) {
+                        continue;
+                    }
+                    let inner_arr = arr.value(row);
+                    let values = inner_arr.as_any().downcast_ref::<Float64Array>()?;
+                    let len = values.values().len();
+                    match uniform_len {
+                        None => uniform_len = Some(len),
+                        Some(prev) if prev == len => {}
+                        Some(_) => {
+                            mixed = true;
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+
+            if !mixed {
+                if let Some(inner_len) = uniform_len {
+                    if inner_len > 0 {
+                        // Column-major fill: rows of the matrix are draws,
+                        // columns are inner positions. Null rows are filled
+                        // with NA.
+                        let mut out = Doubles::new(total * inner_len);
+                        let dest: &mut [Rfloat] = &mut out;
+                        for (chain_idx, arr) in arrs.iter().enumerate() {
+                            for k in 0..n_draws {
+                                let row = skip + k;
+                                let dest_row = chain_idx * n_draws + k;
+                                if arr.is_null(row) {
+                                    for col in 0..inner_len {
+                                        dest[dest_row + col * total] = Rfloat::na();
+                                    }
+                                    continue;
+                                }
+                                let inner_arr = arr.value(row);
+                                let values =
+                                    inner_arr.as_any().downcast_ref::<Float64Array>()?;
+                                let slice: &[f64] = values.values();
+                                for (col, &val) in slice.iter().enumerate() {
+                                    dest[dest_row + col * total] = Rfloat::from(val);
+                                }
+                            }
+                        }
+                        let mut robj: Robj = out.into();
+                        robj.set_attrib(
+                            "dim",
+                            [total as i32, inner_len as i32].into_robj(),
+                        )
+                        .ok()?;
+                        return Some(robj);
+                    }
+                }
+            }
+
+            // Fallback: variable-width or all-empty rows -> list of vectors.
+            let mut out: Vec<Robj> = Vec::with_capacity(total);
+            for arr in &arrs {
+                for k in 0..n_draws {
+                    let row = skip + k;
+                    if arr.is_null(row) {
                         out.push(().into_robj());
                         continue;
                     }
-                    let inner_arr = list_arr.value(row);
+                    let inner_arr = arr.value(row);
                     let values = inner_arr.as_any().downcast_ref::<Float64Array>()?;
                     let slice: &[f64] = values.values();
                     if slice.is_empty() {

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -8,7 +8,7 @@ use arrow::datatypes::DataType;
 use extendr_api::prelude::*;
 use extendr_api::error::Result;
 use nuts_rs::{
-    ArrowConfig, ArrowTrace, ChainProgress, DiagGradNutsSettings, LowRankNutsSettings,
+    ArrowConfig, ArrowTrace, ChainProgress, DiagNutsSettings, LowRankNutsSettings,
     ProgressCallback, Sampler, SamplerWaitResult, Settings,
 };
 use std::path::PathBuf;
@@ -80,9 +80,17 @@ fn compile_stan_model_impl(
     let bs_path = bridgestan::download_bridgestan_src().map_err(r_err)?;
     let stan_path = PathBuf::from(stan_file);
 
-    let stanc_vec: Vec<String> = stanc_args.iter().map(|s| s.to_string()).collect();
+    let stanc_vec: Vec<String> = if stanc_args.len() == 0 {
+        Vec::new()
+    } else {
+        stanc_args.iter().map(|s| s.to_string()).collect()
+    };
     let stanc_refs: Vec<&str> = stanc_vec.iter().map(String::as_str).collect();
-    let compile_vec: Vec<String> = compile_args.iter().map(|s| s.to_string()).collect();
+    let compile_vec: Vec<String> = if compile_args.len() == 0 {
+        Vec::new()
+    } else {
+        compile_args.iter().map(|s| s.to_string()).collect()
+    };
     let compile_refs: Vec<&str> = compile_vec.iter().map(String::as_str).collect();
 
     let lib_path = bridgestan::compile_model(&bs_path, &stan_path, &stanc_refs, &compile_refs)
@@ -234,6 +242,8 @@ fn run_sampler<S: Settings>(
 /// @param mindepth Optional minimum tree depth for NUTS.
 /// @param target_accept Optional target acceptance probability.
 /// @param max_energy_error Optional energy-error divergence threshold.
+/// @param extra_doublings Optional number of extra tree doublings after a
+///   turning point is reached.
 /// @param mass_matrix_gamma Optional regularisation parameter for low-rank
 ///   mass matrix.
 /// @param eigval_cutoff Optional eigenvalue cutoff for low-rank mass matrix.
@@ -273,6 +283,7 @@ fn sample_stan(
     mindepth: Robj,
     target_accept: Robj,
     max_energy_error: Robj,
+    extra_doublings: Robj,
     mass_matrix_gamma: Robj,
     eigval_cutoff: Robj,
     keep_indices: Robj,
@@ -309,6 +320,7 @@ fn sample_stan(
     let target_accept_opt =
         opt_finite_in_open_unit(&target_accept, "target_accept")?;
     let max_energy_error_opt = opt_finite_positive_f64(&max_energy_error, "max_energy_error")?;
+    let extra_doublings_opt = opt_count(&extra_doublings, "extra_doublings", 0)?;
 
     let init_positions_raw: Option<Vec<Vec<f64>>> = if init_positions.is_null() {
         None
@@ -382,6 +394,9 @@ fn sample_stan(
             if let Some(v) = max_energy_error_opt {
                 $settings.max_energy_error = v;
             }
+            if let Some(v) = extra_doublings_opt {
+                $settings.extra_doublings = v as u64;
+            }
             $settings.store_divergences = store_divergences;
             $settings.store_unconstrained = store_unconstrained;
             $settings.store_gradient = store_gradient;
@@ -402,7 +417,7 @@ fn sample_stan(
             run_with_settings(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?
         }
         "diag" => {
-            let mut settings = DiagGradNutsSettings::default();
+            let mut settings = DiagNutsSettings::default();
             configure_settings!(settings);
             run_with_settings(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?
         }
@@ -616,6 +631,7 @@ fn column_to_robj(
     dtype: &DataType,
     skip: usize,
     n_draws: usize,
+    carry_forward: bool,
 ) -> Option<Robj> {
     let total = cols.len() * n_draws;
 
@@ -710,9 +726,10 @@ fn column_to_robj(
 
             let mut uniform_len: Option<usize> = None;
             let mut mixed = false;
+            let scan_start = if carry_forward { 0 } else { skip };
+            let scan_end = skip + n_draws;
             'outer: for arr in &arrs {
-                for k in 0..n_draws {
-                    let row = skip + k;
+                for row in scan_start..scan_end {
                     if arr.is_null(row) {
                         continue;
                     }
@@ -740,19 +757,36 @@ fn column_to_robj(
                                 .downcast_ref::<Float64Array>()?
                                 .values();
                             let offsets = arr.value_offsets();
+                            let mut last: Option<Vec<f64>> = None;
+                            if carry_forward && skip > 0 {
+                                for row in 0..skip {
+                                    if !arr.is_null(row) {
+                                        let start = offsets[row] as usize;
+                                        last = Some(inner_values[start..start + inner_len].to_vec());
+                                    }
+                                }
+                            }
                             for k in 0..n_draws {
                                 let row = skip + k;
                                 let dest_row = chain_idx * n_draws + k;
-                                if arr.is_null(row) {
-                                    for col in 0..inner_len {
-                                        dest[dest_row + col * total] = Rfloat::na();
+                                let row_values: Option<&[f64]> = if arr.is_null(row) {
+                                    last.as_deref()
+                                } else {
+                                    let start = offsets[row] as usize;
+                                    last = Some(inner_values[start..start + inner_len].to_vec());
+                                    last.as_deref()
+                                };
+                                match row_values {
+                                    Some(vals) => {
+                                        for (col, &val) in vals.iter().enumerate() {
+                                            dest[dest_row + col * total] = Rfloat::from(val);
+                                        }
                                     }
-                                    continue;
-                                }
-                                let start = offsets[row] as usize;
-                                let row_slice = &inner_values[start..start + inner_len];
-                                for (col, &val) in row_slice.iter().enumerate() {
-                                    dest[dest_row + col * total] = Rfloat::from(val);
+                                    None => {
+                                        for col in 0..inner_len {
+                                            dest[dest_row + col * total] = Rfloat::na();
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -833,14 +867,16 @@ fn extract_diagnostics(
 
         // Drop columns that are entirely null in the requested window
         // (e.g. mass_matrix_inv / divergence_* when their flags are off).
+        let carry_forward = name.starts_with("mass_matrix");
+        let non_null_start = if carry_forward { 0 } else { skip };
         let any_non_null = cols.iter().any(|c| {
-            (skip..skip + n_draws).any(|row| row < c.len() && !c.is_null(row))
+            (non_null_start..skip + n_draws).any(|row| row < c.len() && !c.is_null(row))
         });
         if !any_non_null {
             continue;
         }
 
-        match column_to_robj(&cols, field.data_type(), skip, n_draws) {
+        match column_to_robj(&cols, field.data_type(), skip, n_draws, carry_forward) {
             Some(robj) => {
                 names.push(name.clone());
                 values.push(robj);

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -309,8 +309,6 @@ fn sample_stan(
     let target_accept_opt =
         opt_finite_in_open_unit(&target_accept, "target_accept")?;
     let max_energy_error_opt = opt_finite_positive_f64(&max_energy_error, "max_energy_error")?;
-    let mass_matrix_gamma_opt = opt_finite_positive_f64(&mass_matrix_gamma, "mass_matrix_gamma")?;
-    let eigval_cutoff_opt = opt_finite_positive_f64(&eigval_cutoff, "eigval_cutoff")?;
 
     let init_positions_raw: Option<Vec<Vec<f64>>> = if init_positions.is_null() {
         None
@@ -395,10 +393,10 @@ fn sample_stan(
         "low_rank" => {
             let mut settings = LowRankNutsSettings::default();
             configure_settings!(settings);
-            if let Some(v) = mass_matrix_gamma_opt {
+            if let Some(v) = opt_finite_positive_f64(&mass_matrix_gamma, "mass_matrix_gamma")? {
                 settings.adapt_options.mass_matrix_options.gamma = v;
             }
-            if let Some(v) = eigval_cutoff_opt {
+            if let Some(v) = opt_finite_positive_f64(&eigval_cutoff, "eigval_cutoff")? {
                 settings.adapt_options.mass_matrix_options.eigval_cutoff = v;
             }
             run_with_settings(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -236,7 +236,7 @@ fn run_sampler<S: Settings>(
 /// @param store_mass_matrix Whether to store the mass matrix at each draw.
 /// @param store_unconstrained Whether to store the unconstrained position at each draw.
 /// @param store_gradient Whether to store the gradient at each draw.
-/// @param adaptation One of "diag" or "low_rank".
+/// @param adaptation One of "diag", "low_rank", or "low-rank".
 /// @param max_treedepth Optional maximum tree depth for NUTS. NULL keeps the
 ///   nuts-rs default.
 /// @param mindepth Optional minimum tree depth for NUTS.
@@ -405,7 +405,7 @@ fn sample_stan(
     }
 
     let (results, sampler_config_json) = match adaptation {
-        "low_rank" => {
+        "low_rank" | "low-rank" => {
             let mut settings = LowRankNutsSettings::default();
             configure_settings!(settings);
             if let Some(v) = opt_finite_positive_f64(&mass_matrix_gamma, "mass_matrix_gamma")? {
@@ -423,7 +423,7 @@ fn sample_stan(
         }
         other => {
             return Err(Error::Other(format!(
-                "adaptation must be one of \"diag\" or \"low_rank\", got \"{}\"",
+                "adaptation must be one of \"diag\", \"low_rank\", or \"low-rank\", got \"{}\"",
                 other
             )));
         }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -80,17 +80,9 @@ fn compile_stan_model_impl(
     let bs_path = bridgestan::download_bridgestan_src().map_err(r_err)?;
     let stan_path = PathBuf::from(stan_file);
 
-    let stanc_vec: Vec<String> = if stanc_args.len() == 0 {
-        Vec::new()
-    } else {
-        stanc_args.iter().map(|s| s.to_string()).collect()
-    };
+    let stanc_vec: Vec<String> = stanc_args.iter().map(|s| s.to_string()).collect();
     let stanc_refs: Vec<&str> = stanc_vec.iter().map(String::as_str).collect();
-    let compile_vec: Vec<String> = if compile_args.len() == 0 {
-        Vec::new()
-    } else {
-        compile_args.iter().map(|s| s.to_string()).collect()
-    };
+    let compile_vec: Vec<String> = compile_args.iter().map(|s| s.to_string()).collect();
     let compile_refs: Vec<&str> = compile_vec.iter().map(String::as_str).collect();
 
     let lib_path = bridgestan::compile_model(&bs_path, &stan_path, &stanc_refs, &compile_refs)
@@ -236,7 +228,8 @@ fn run_sampler<S: Settings>(
 /// @param store_mass_matrix Whether to store the mass matrix at each draw.
 /// @param store_unconstrained Whether to store the unconstrained position at each draw.
 /// @param store_gradient Whether to store the gradient at each draw.
-/// @param adaptation One of "diag", "low_rank", or "low-rank".
+/// @param adaptation One of "diag" or "low_rank". The R wrapper accepts
+///   "low-rank" as a Python-style alias and normalises it before calling.
 /// @param max_treedepth Optional maximum tree depth for NUTS. NULL keeps the
 ///   nuts-rs default.
 /// @param mindepth Optional minimum tree depth for NUTS.
@@ -405,7 +398,7 @@ fn sample_stan(
     }
 
     let (results, sampler_config_json) = match adaptation {
-        "low_rank" | "low-rank" => {
+        "low_rank" => {
             let mut settings = LowRankNutsSettings::default();
             configure_settings!(settings);
             if let Some(v) = opt_finite_positive_f64(&mass_matrix_gamma, "mass_matrix_gamma")? {
@@ -423,7 +416,7 @@ fn sample_stan(
         }
         other => {
             return Err(Error::Other(format!(
-                "adaptation must be one of \"diag\", \"low_rank\", or \"low-rank\", got \"{}\"",
+                "adaptation must be one of \"diag\" or \"low_rank\", got \"{}\"",
                 other
             )));
         }
@@ -757,28 +750,31 @@ fn column_to_robj(
                                 .downcast_ref::<Float64Array>()?
                                 .values();
                             let offsets = arr.value_offsets();
-                            let mut last: Option<Vec<f64>> = None;
-                            if carry_forward && skip > 0 {
-                                for row in 0..skip {
-                                    if !arr.is_null(row) {
-                                        let start = offsets[row] as usize;
-                                        last = Some(inner_values[start..start + inner_len].to_vec());
-                                    }
-                                }
-                            }
+                            // Carry the most recent non-null row's offset
+                            // forward; `inner_values` outlives the loop, so
+                            // a usize is enough — no per-row Vec clone.
+                            let mut last_start: Option<usize> = if carry_forward {
+                                (0..skip).rev().find(|&r| !arr.is_null(r))
+                                    .map(|r| offsets[r] as usize)
+                            } else {
+                                None
+                            };
                             for k in 0..n_draws {
                                 let row = skip + k;
                                 let dest_row = chain_idx * n_draws + k;
-                                let row_values: Option<&[f64]> = if arr.is_null(row) {
-                                    last.as_deref()
+                                let src_start = if arr.is_null(row) {
+                                    last_start
                                 } else {
-                                    let start = offsets[row] as usize;
-                                    last = Some(inner_values[start..start + inner_len].to_vec());
-                                    last.as_deref()
+                                    let s = offsets[row] as usize;
+                                    if carry_forward {
+                                        last_start = Some(s);
+                                    }
+                                    Some(s)
                                 };
-                                match row_values {
-                                    Some(vals) => {
-                                        for (col, &val) in vals.iter().enumerate() {
+                                match src_start {
+                                    Some(start) => {
+                                        let src = &inner_values[start..start + inner_len];
+                                        for (col, &val) in src.iter().enumerate() {
                                             dest[dest_row + col * total] = Rfloat::from(val);
                                         }
                                     }
@@ -865,9 +861,16 @@ fn extract_diagnostics(
             .map(|t| t.sample_stats.column(idx).as_ref())
             .collect();
 
-        // Drop columns that are entirely null in the requested window
-        // (e.g. mass_matrix_inv / divergence_* when their flags are off).
-        let carry_forward = name.starts_with("mass_matrix");
+        // The mass-matrix snapshots only land on update rows; treat them
+        // as piecewise-constant and carry the most recent value forward
+        // through the NA gaps. Other columns get the default null-is-NA
+        // behaviour. Explicit list, not a prefix match, so a future
+        // upstream `mass_matrix_*` column doesn't silently inherit
+        // carry-forward semantics it may not warrant.
+        let carry_forward = matches!(
+            name.as_str(),
+            "mass_matrix_inv" | "mass_matrix_eigvals" | "mass_matrix_stds"
+        );
         let non_null_start = if carry_forward { 0 } else { skip };
         let any_non_null = cols.iter().any(|c| {
             (non_null_start..skip + n_draws).any(|row| row < c.len() && !c.is_null(row))

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -304,46 +304,13 @@ fn sample_stan(
     }
     check_seed(seed)?;
 
-    // Optional config knobs. NULL on the R side leaves the nuts-rs default
-    // in place — we don't second-guess upstream tuning choices.
     let max_treedepth_opt = opt_count(&max_treedepth, "max_treedepth", 1)?;
     let mindepth_opt = opt_count(&mindepth, "mindepth", 0)?;
-    let target_accept_opt = opt_finite_f64(&target_accept, "target_accept")?;
-    if let Some(v) = target_accept_opt {
-        if !(v > 0.0 && v < 1.0) {
-            return Err(Error::Other(format!(
-                "target_accept must be in (0, 1), got {}",
-                v
-            )));
-        }
-    }
-    let max_energy_error_opt = opt_finite_f64(&max_energy_error, "max_energy_error")?;
-    if let Some(v) = max_energy_error_opt {
-        if !(v > 0.0) {
-            return Err(Error::Other(format!(
-                "max_energy_error must be > 0, got {}",
-                v
-            )));
-        }
-    }
-    let mass_matrix_gamma_opt = opt_finite_f64(&mass_matrix_gamma, "mass_matrix_gamma")?;
-    if let Some(v) = mass_matrix_gamma_opt {
-        if !(v > 0.0) {
-            return Err(Error::Other(format!(
-                "mass_matrix_gamma must be > 0, got {}",
-                v
-            )));
-        }
-    }
-    let eigval_cutoff_opt = opt_finite_f64(&eigval_cutoff, "eigval_cutoff")?;
-    if let Some(v) = eigval_cutoff_opt {
-        if !(v > 0.0) {
-            return Err(Error::Other(format!(
-                "eigval_cutoff must be > 0, got {}",
-                v
-            )));
-        }
-    }
+    let target_accept_opt =
+        opt_finite_in_open_unit(&target_accept, "target_accept")?;
+    let max_energy_error_opt = opt_finite_positive_f64(&max_energy_error, "max_energy_error")?;
+    let mass_matrix_gamma_opt = opt_finite_positive_f64(&mass_matrix_gamma, "mass_matrix_gamma")?;
+    let eigval_cutoff_opt = opt_finite_positive_f64(&eigval_cutoff, "eigval_cutoff")?;
 
     let init_positions_raw: Option<Vec<Vec<f64>>> = if init_positions.is_null() {
         None
@@ -434,18 +401,12 @@ fn sample_stan(
             if let Some(v) = eigval_cutoff_opt {
                 settings.adapt_options.mass_matrix_options.eigval_cutoff = v;
             }
-            let json = serde_json::to_string(&settings)
-                .map_err(|e| Error::Other(format!("failed to serialize sampler settings: {}", e)))?;
-            let r = run_sampler(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?;
-            (r, json)
+            run_with_settings(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?
         }
         "diag" => {
             let mut settings = DiagGradNutsSettings::default();
             configure_settings!(settings);
-            let json = serde_json::to_string(&settings)
-                .map_err(|e| Error::Other(format!("failed to serialize sampler settings: {}", e)))?;
-            let r = run_sampler(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?;
-            (r, json)
+            run_with_settings(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh)?
         }
         other => {
             return Err(Error::Other(format!(
@@ -508,40 +469,9 @@ fn sample_stan(
     })())
 }
 
-/// Coerce an optional R scalar (`NULL`, integer, or numeric) to `Option<i32>`.
-/// Validates finiteness, integral-ness, and a `>= min` bound. Used by the
-/// FFI for sampler config knobs that should only override the nuts-rs
-/// default when the R caller explicitly passes a value.
-fn opt_count(robj: &Robj, name: &str, min: i32) -> Result<Option<i32>> {
-    if robj.is_null() {
-        return Ok(None);
-    }
-    let v: f64 = robj
-        .as_real()
-        .ok_or_else(|| Error::Other(format!("`{}` must be NULL or a single numeric.", name)))?;
-    if !v.is_finite() {
-        return Err(Error::Other(format!("`{}` must be a finite integer.", name)));
-    }
-    if v.fract() != 0.0 {
-        return Err(Error::Other(format!(
-            "`{}` must be a whole number, got {}.",
-            name, v
-        )));
-    }
-    if v < min as f64 || v > i32::MAX as f64 {
-        return Err(Error::Other(format!(
-            "`{}` must be in [{}, {}], got {}.",
-            name,
-            min,
-            i32::MAX,
-            v
-        )));
-    }
-    Ok(Some(v as i32))
-}
-
-/// Coerce an optional R scalar (`NULL` or numeric) to `Option<f64>`.
-/// Validates finiteness only — caller does range checks.
+/// Optional finite scalar (`NULL` -> None, REAL scalar -> Some). Caller does
+/// any range checks. Mirrors the R-side `check_count` so direct FFI callers
+/// can't bypass validation.
 fn opt_finite_f64(robj: &Robj, name: &str) -> Result<Option<f64>> {
     if robj.is_null() {
         return Ok(None);
@@ -553,6 +483,59 @@ fn opt_finite_f64(robj: &Robj, name: &str) -> Result<Option<f64>> {
         return Err(Error::Other(format!("`{}` must be a finite number.", name)));
     }
     Ok(Some(v))
+}
+
+fn opt_finite_positive_f64(robj: &Robj, name: &str) -> Result<Option<f64>> {
+    let v = opt_finite_f64(robj, name)?;
+    if let Some(x) = v {
+        if !(x > 0.0) {
+            return Err(Error::Other(format!("`{}` must be > 0, got {}.", name, x)));
+        }
+    }
+    Ok(v)
+}
+
+fn opt_finite_in_open_unit(robj: &Robj, name: &str) -> Result<Option<f64>> {
+    let v = opt_finite_f64(robj, name)?;
+    if let Some(x) = v {
+        if !(x > 0.0 && x < 1.0) {
+            return Err(Error::Other(format!("`{}` must be in (0, 1), got {}.", name, x)));
+        }
+    }
+    Ok(v)
+}
+
+fn opt_count(robj: &Robj, name: &str, min: i32) -> Result<Option<i32>> {
+    let Some(v) = opt_finite_f64(robj, name)? else { return Ok(None); };
+    if v.fract() != 0.0 {
+        return Err(Error::Other(format!("`{}` must be a whole number, got {}.", name, v)));
+    }
+    if v < min as f64 || v > i32::MAX as f64 {
+        return Err(Error::Other(format!(
+            "`{}` must be in [{}, {}], got {}.",
+            name, min, i32::MAX, v
+        )));
+    }
+    Ok(Some(v as i32))
+}
+
+/// Run the sampler with `settings` and return the traces alongside a JSON
+/// snapshot of the effective settings (surfaced via `attr(draws, "sampler_config")`).
+fn run_with_settings<S: Settings + serde::Serialize>(
+    stan_model: model::StanModel,
+    settings: S,
+    num_chains: i32,
+    num_draws: i32,
+    num_warmup: i32,
+    num_cores: i32,
+    refresh: i32,
+) -> Result<(Vec<ArrowTrace>, String)> {
+    let json = serde_json::to_string(&settings)
+        .map_err(|e| Error::Other(format!("failed to serialize sampler settings: {}", e)))?;
+    let traces = run_sampler(
+        stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh,
+    )?;
+    Ok((traces, json))
 }
 
 /// Build a draws matrix from Arrow traces.
@@ -719,12 +702,9 @@ fn column_to_robj(
         DataType::Int32 => build_int_or_double!(Int32Array, |v: i32| v > i32::MIN),
         DataType::UInt32 => build_int_or_double!(UInt32Array, |v: u32| v <= i32::MAX as u32),
         DataType::LargeList(inner) if matches!(inner.data_type(), DataType::Float64) => {
-            // First pass: collect downcasted handles, check whether every
-            // non-null row in the requested window has the same inner length.
-            // If so (e.g. `mass_matrix_inv`, `mass_matrix_eigvals`,
-            // `mass_matrix_stds`, all `ndim_unc` wide), surface a 2-D
-            // `(total, inner_len)` matrix instead of a list-of-vectors —
-            // much friendlier downstream.
+            // Uniform-width rows (mass_matrix_inv / _eigvals / _stds — all
+            // ndim_unc wide) collapse to a 2-D matrix; mixed widths fall
+            // back to a list-of-vectors.
             let arrs: Vec<&LargeListArray> = cols
                 .iter()
                 .map(|c| c.as_any().downcast_ref::<LargeListArray>())
@@ -738,9 +718,7 @@ fn column_to_robj(
                     if arr.is_null(row) {
                         continue;
                     }
-                    let inner_arr = arr.value(row);
-                    let values = inner_arr.as_any().downcast_ref::<Float64Array>()?;
-                    let len = values.values().len();
+                    let len = arr.value_length(row) as usize;
                     match uniform_len {
                         None => uniform_len = Some(len),
                         Some(prev) if prev == len => {}
@@ -755,12 +733,15 @@ fn column_to_robj(
             if !mixed {
                 if let Some(inner_len) = uniform_len {
                     if inner_len > 0 {
-                        // Column-major fill: rows of the matrix are draws,
-                        // columns are inner positions. Null rows are filled
-                        // with NA.
                         let mut out = Doubles::new(total * inner_len);
                         let dest: &mut [Rfloat] = &mut out;
                         for (chain_idx, arr) in arrs.iter().enumerate() {
+                            let inner_values = arr
+                                .values()
+                                .as_any()
+                                .downcast_ref::<Float64Array>()?
+                                .values();
+                            let offsets = arr.value_offsets();
                             for k in 0..n_draws {
                                 let row = skip + k;
                                 let dest_row = chain_idx * n_draws + k;
@@ -770,11 +751,9 @@ fn column_to_robj(
                                     }
                                     continue;
                                 }
-                                let inner_arr = arr.value(row);
-                                let values =
-                                    inner_arr.as_any().downcast_ref::<Float64Array>()?;
-                                let slice: &[f64] = values.values();
-                                for (col, &val) in slice.iter().enumerate() {
+                                let start = offsets[row] as usize;
+                                let row_slice = &inner_values[start..start + inner_len];
+                                for (col, &val) in row_slice.iter().enumerate() {
                                     dest[dest_row + col * total] = Rfloat::from(val);
                                 }
                             }
@@ -790,18 +769,23 @@ fn column_to_robj(
                 }
             }
 
-            // Fallback: variable-width or all-empty rows -> list of vectors.
             let mut out: Vec<Robj> = Vec::with_capacity(total);
             for arr in &arrs {
+                let inner_values = arr
+                    .values()
+                    .as_any()
+                    .downcast_ref::<Float64Array>()?
+                    .values();
+                let offsets = arr.value_offsets();
                 for k in 0..n_draws {
                     let row = skip + k;
                     if arr.is_null(row) {
                         out.push(().into_robj());
                         continue;
                     }
-                    let inner_arr = arr.value(row);
-                    let values = inner_arr.as_any().downcast_ref::<Float64Array>()?;
-                    let slice: &[f64] = values.values();
+                    let start = offsets[row] as usize;
+                    let end = offsets[row + 1] as usize;
+                    let slice = &inner_values[start..end];
                     if slice.is_empty() {
                         out.push(().into_robj());
                     } else {

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -120,6 +120,16 @@ test_that("adaptation = 'low_rank' matches the deprecated flag's behaviour", {
   expect_equal(as.numeric(draws_new), as.numeric(draws_old))
 })
 
+test_that("adaptation = 'low-rank' is accepted as an alias", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  draws <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                         num_draws = 50, num_warmup = 50, num_chains = 1,
+                         seed = 1L, refresh = 0, adaptation = "low-rank")
+  expect_s3_class(draws, "draws_array")
+  cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"))
+  expect_equal(cfg$adapt_options$mass_matrix_update_freq, 20)
+})
+
 # --- resolve_constrain_flags_impl unit tests (no handle) ---------------------
 
 test_that("resolve_constrain_flags short-circuits without touching the handle when pars is NULL", {

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -99,8 +99,8 @@ test_that("low_rank_modified_mass_matrix is deprecated but still works", {
   )
   expect_s3_class(draws, "draws_array")
   cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"))
-  # low_rank settings have a `mass_matrix_update_freq` of 10 (vs. 1 for diag).
-  expect_equal(cfg$adapt_options$mass_matrix_update_freq, 10)
+  # low_rank settings have a `mass_matrix_update_freq` of 20 (vs. 1 for diag).
+  expect_equal(cfg$adapt_options$mass_matrix_update_freq, 20)
 })
 
 test_that("adaptation = 'low_rank' matches the deprecated flag's behaviour", {
@@ -489,8 +489,8 @@ test_that("sampler_config is parseable JSON capturing effective settings", {
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
   draws <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
                          num_draws = 50, num_warmup = 50, num_chains = 1,
-                         seed = 1L, refresh = 0,
-                         target_accept = 0.9, max_treedepth = 8L)
+                         seed = 1L, refresh = 0, target_accept = 0.9,
+                         max_treedepth = 8L, extra_doublings = 2L)
   cfg_str <- attr(draws, "sampler_config")
   expect_type(cfg_str, "character")
   expect_true(nzchar(cfg_str))
@@ -498,6 +498,7 @@ test_that("sampler_config is parseable JSON capturing effective settings", {
   expect_equal(cfg$num_tune, 50)
   expect_equal(cfg$num_draws, 50)
   expect_equal(cfg$maxdepth, 8)
+  expect_equal(cfg$extra_doublings, 2)
   expect_equal(cfg$adapt_options$step_size_settings$target_accept, 0.9)
 })
 

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -88,20 +88,36 @@ test_that("cores defaults to 1 when detectCores returns NA", {
   expect_s3_class(draws, "draws_array")
 })
 
-test_that("low_rank bumps default num_warmup to 800", {
+test_that("low_rank_modified_mass_matrix is deprecated but still works", {
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
-  draws <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
-                         num_draws = 50, num_chains = 1, seed = 1L,
-                         refresh = 0,
-                         low_rank_modified_mass_matrix = TRUE)
-  expect_equal(attr(draws, "num_warmup"), 800L)
+  expect_warning(
+    draws <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                           num_draws = 50, num_warmup = 50, num_chains = 1,
+                           seed = 1L, refresh = 0,
+                           low_rank_modified_mass_matrix = TRUE),
+    "deprecated"
+  )
+  expect_s3_class(draws, "draws_array")
+  cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"))
+  # low_rank settings have a `mass_matrix_update_freq` of 10 (vs. 1 for diag).
+  expect_equal(cfg$adapt_options$mass_matrix_update_freq, 10)
+})
 
-  # explicit value still wins
-  draws2 <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
-                          num_draws = 50, num_warmup = 200L, num_chains = 1,
-                          seed = 1L, refresh = 0,
-                          low_rank_modified_mass_matrix = TRUE)
-  expect_equal(attr(draws2, "num_warmup"), 200L)
+test_that("adaptation = 'low_rank' matches the deprecated flag's behaviour", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  draws_new <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                             num_draws = 100, num_warmup = 100, num_chains = 1,
+                             seed = 1L, refresh = 0,
+                             adaptation = "low_rank")
+  expect_warning(
+    draws_old <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                               num_draws = 100, num_warmup = 100,
+                               num_chains = 1, seed = 1L, refresh = 0,
+                               low_rank_modified_mass_matrix = TRUE),
+    "deprecated"
+  )
+  # Same seed + same path should yield identical draws.
+  expect_equal(as.numeric(draws_new), as.numeric(draws_old))
 })
 
 # --- resolve_constrain_flags_impl unit tests (no handle) ---------------------
@@ -384,8 +400,9 @@ test_that("bernoulli pars = 'theta' exercises the (FALSE, FALSE) flag path", {
 test_that("store_unconstrained / gradient / mass_matrix surface their columns", {
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
 
+  num_draws <- 50
   draws <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
-    num_draws = 50, num_chains = 1, seed = 42, refresh = 0,
+    num_draws = num_draws, num_chains = 1, seed = 42, refresh = 0,
     store_unconstrained = TRUE, store_gradient = TRUE, store_mass_matrix = TRUE
   )
   diag <- nutpie_diagnostics(draws)
@@ -393,19 +410,14 @@ test_that("store_unconstrained / gradient / mass_matrix surface their columns", 
   expect_true("unconstrained_draw" %in% names(diag))
   expect_true("gradient" %in% names(diag))
   expect_true("mass_matrix_inv" %in% names(diag))
-  expect_type(diag$unconstrained_draw, "list")
-  expect_type(diag$gradient, "list")
-  expect_type(diag$mass_matrix_inv, "list")
 
-  # Bernoulli has 1 unconstrained parameter
-  expect_equal(length(diag$unconstrained_draw[[1]]), 1L)
-  expect_equal(length(diag$gradient[[1]]), 1L)
-
-  # mass_matrix_inv typically populates after warmup; some entries must be
-  # numeric vectors
-  non_null <- Filter(Negate(is.null), diag$mass_matrix_inv)
-  expect_true(length(non_null) > 0L)
-  expect_type(non_null[[1]], "double")
+  # Bernoulli has 1 unconstrained parameter, so each list-of-vectors column
+  # collapses to a (num_draws, 1) numeric matrix via the uniform-width path.
+  for (col in c("unconstrained_draw", "gradient", "mass_matrix_inv")) {
+    expect_true(is.matrix(diag[[col]]), info = col)
+    expect_type(diag[[col]], "double")
+    expect_equal(dim(diag[[col]]), c(num_draws, 1L), info = col)
+  }
 })
 
 # --- store_divergences detail (conditional) ----------------------------------
@@ -433,7 +445,7 @@ test_that("store_divergences exposes divergence detail when divergences occur", 
 
 # --- low-rank mass matrix ----------------------------------------------------
 
-test_that("low_rank_modified_mass_matrix produces valid draws", {
+test_that("adaptation = 'low_rank' produces valid draws", {
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
 
   # store_mass_matrix is requested too: low-rank's mass matrix has a
@@ -442,7 +454,7 @@ test_that("low_rank_modified_mass_matrix produces valid draws", {
   # logp populated.
   draws <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
     num_draws = 100, num_chains = 2, seed = 42, refresh = 0,
-    low_rank_modified_mass_matrix = TRUE, store_mass_matrix = TRUE
+    adaptation = "low_rank", store_mass_matrix = TRUE
   )
   expect_s3_class(draws, "draws_array")
   expect_equal(posterior::niterations(draws), 100)
@@ -469,6 +481,56 @@ test_that("sampling with bad data gives R error, not crash", {
     nutpie_sample(test_models$bernoulli, data = '{"bad": "json format"}',
                   num_draws = 10, num_chains = 1, seed = 42, refresh = 0)
   )
+})
+
+# --- sampler_config attribute ------------------------------------------------
+
+test_that("sampler_config is parseable JSON capturing effective settings", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  draws <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                         num_draws = 50, num_warmup = 50, num_chains = 1,
+                         seed = 1L, refresh = 0,
+                         target_accept = 0.9, max_treedepth = 8L)
+  cfg_str <- attr(draws, "sampler_config")
+  expect_type(cfg_str, "character")
+  expect_true(nzchar(cfg_str))
+  cfg <- jsonlite::fromJSON(cfg_str)
+  expect_equal(cfg$num_tune, 50)
+  expect_equal(cfg$num_draws, 50)
+  expect_equal(cfg$maxdepth, 8)
+  expect_equal(cfg$adapt_options$step_size_settings$target_accept, 0.9)
+})
+
+test_that("unspecified target_accept / max_treedepth use nuts-rs defaults", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  draws <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                         num_draws = 50, num_warmup = 50, num_chains = 1,
+                         seed = 1L, refresh = 0)
+  expect_s3_class(draws, "draws_array")
+  cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"))
+  # nuts-rs DiagGradNutsSettings defaults: maxdepth = 10, target_accept = 0.8.
+  expect_equal(cfg$maxdepth, 10)
+  expect_equal(cfg$adapt_options$step_size_settings$target_accept, 0.8)
+})
+
+# --- mass_matrix_inv shape ---------------------------------------------------
+
+test_that("store_mass_matrix surfaces mass_matrix_inv as a numeric matrix", {
+  skip_if(is.null(test_models$normal), "Normal model not compiled")
+  num_draws <- 60
+  num_chains <- 2
+  draws <- nutpie_sample(test_models$normal, data = normal_data(),
+                         num_draws = num_draws, num_warmup = 80,
+                         num_chains = num_chains, seed = 1L, refresh = 0,
+                         store_mass_matrix = TRUE)
+  diag <- nutpie_diagnostics(draws)
+  mm <- diag$mass_matrix_inv
+  expect_true(is.matrix(mm))
+  expect_type(mm, "double")
+  ndim_unc <- length(nutpie_param_names(test_models$normal,
+                                        data = normal_data(),
+                                        which = "unconstrained"))
+  expect_equal(dim(mm), c(num_draws * num_chains, ndim_unc))
 })
 
 # --- diagnostics on a non-nutpie object --------------------------------------


### PR DESCRIPTION
Bundles five of the seven points from #18 on top of the README fix already on this branch.

## What ships

- **#4** — `adaptation = c("diag", "low_rank")` argument on `nutpie_sample()` (matches Python nutpie, `"low-rank"` accepted as a hyphenated alias). `low_rank_modified_mass_matrix` is soft-deprecated.
- **#6** — `mindepth`, `max_energy_error`, and `extra_doublings` exposed as optional args. `extra_doublings` came in via the nuts-rs 0.18 bump (it didn't exist in 0.17).
- **#3** — `target_accept`, `max_treedepth`, `mass_matrix_gamma`, `mass_matrix_eigval_cutoff` default to `NULL` and pass through to nuts-rs's defaults instead of overwriting them. Drops the prior 800-warmup low-rank bump on the same principle.
- **#2** — `attr(draws, "sampler_config")` carries the *effective* sampler settings as a JSON string (`serde_json` on `NutsSettings`); parse with `jsonlite::fromJSON()`.
- **#7** — Uniform-width `LargeList<Float64>` diagnostics (`mass_matrix_inv` etc.) surface as `(n_draws * n_chains, ndim_unc)` numeric matrices instead of lists of vectors. Mass-matrix snapshots also carry the most-recent value forward through the NA gaps between adapter updates, since the inverse mass matrix is piecewise-constant.

Also: nuts-rs `0.17 → 0.18` (with the `DiagGradNutsSettings → DiagNutsSettings` rename), arrow `57 → 58`. Version bumped to **1.7.0**.

## Out of scope

- **#1** progress reporting — deferred pending a conversation with Adrian; the current main-thread polling pattern matches what CmdStanR does.
- **#5** README install line — already shipped on this branch (`25b7be5`).
- `adaptation = "draw_diag"` / `"flow"` — one-line dispatch additions when wanted; gated on whether we want to expose `use_grad_based_mass_matrix` and the transform-adapt path.

## Worth knowing for the review

- `sample_stan` FFI signature is now 25 parameters. Real architectural debt; left for a separate refactor (group `store_*` and the optional sampler knobs into named lists).
- The carry-forward heuristic for mass-matrix columns is an explicit allowlist (`mass_matrix_inv` / `_eigvals` / `_stds`), not a `starts_with("mass_matrix")` prefix match — so a future upstream column doesn't silently inherit the semantics.
- Tests cover the new args, the `sampler_config` round-trip, the mass-matrix matrix shape, and the deprecation warning. `R CMD check` is clean (0 errors / 0 notes; one pre-existing "Downloads Rust crates" WARNING).

## Commits

Six commits, kept separate so each review concern is its own diff:

1. `0492f09` — Adrian feedback: adaptation API, sampler_config, mass-matrix shape (1.7.0)
2. `1c4baa1` — Polish pass: collapse FFI validators, tighten Arrow extraction
3. `b438f92` — Codex review: don't validate low-rank knobs in diag mode; fix diagnostics doc
4. `d2d042a` — Expose extra_doublings via nuts-rs 0.18
5. `8397bf3` — Accept low-rank adaptation alias
6. `42085b3` — Simplify pass: drop per-row Vec, allowlist carry-forward, doc/NEWS catch-up