### PR TITLE
Render Utf8 diagnostic columns as character vectors (1.7.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.7.0
+Version: 1.7.1
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# nutpieR 1.7.1
+
+* Arrow `Utf8` diagnostic columns (e.g. `divergence_message`) now
+  surface as character vectors instead of being skipped.
+
 # nutpieR 1.7.0
 
 * New `adaptation =` argument on `nutpie_sample()` selects the mass-matrix

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -2,7 +2,7 @@
 
 use arrow::array::{
     Array, BooleanArray, Float32Array, Float64Array, Int32Array, Int64Array, LargeListArray,
-    UInt32Array, UInt64Array,
+    StringArray, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::DataType;
 use extendr_api::prelude::*;
@@ -694,6 +694,21 @@ fn column_to_robj(
                     } else {
                         Rbool::from(arr.value(row))
                     };
+                    i += 1;
+                }
+            }
+            Some(out.into())
+        }
+        DataType::Utf8 => {
+            let mut out = Strings::new_with_na(total);
+            let mut i = 0;
+            for c in cols {
+                let arr = c.as_any().downcast_ref::<StringArray>()?;
+                for k in 0..n_draws {
+                    let row = skip + k;
+                    if !arr.is_null(row) {
+                        out.set_elt(i, Rstr::from(arr.value(row)));
+                    }
                     i += 1;
                 }
             }


### PR DESCRIPTION
## Summary

`column_to_robj` had no `DataType::Utf8` arm, so any string column from
nuts-rs's diagnostic schema fell through to the "unsupported Arrow
type" warning path and got dropped from `nutpie_diagnostics()`. In
practice that meant `divergence_message` — populated when a divergence
fires — was never visible from R, and runs with divergences printed:

> nutpieR: skipping diagnostic 'divergence_message' — unsupported Arrow type Utf8

This adds a Utf8 arm that builds an R character vector with `NA` for
non-divergent draws via extendr's `Strings::new_with_na` + `set_elt`
(the manual loop is required — `Strings` has no `DerefMut` so the
slice-write idiom used by the numeric arms doesn't apply, and
`from_values` doesn't carry NA semantics through `Option<&str>`).

The all-null fast path is unchanged: `extract_diagnostics` already
filters columns with no non-null entries before dispatching, so on
divergence-free runs the new arm is never entered.

## Test plan

- [ ] `NOT_CRAN=TRUE devtools::install(quick = TRUE)` then
      `devtools::test()` — 240 pass, 0 fail (existing suite; no new
      tests because the Utf8 column only appears on runs with
      divergences and the bernoulli/normal test fixtures rarely produce
      any).
- [ ] Manual smoke: a run with divergences shows
      `nutpie_diagnostics(draws)$divergence_message` as a character
      vector with `NA` on non-divergent draws and the actual nuts-rs
      message on divergent ones, and the "skipping diagnostic" warning
      no longer prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)