### PR TITLE
fix: normalize path separators in print.nutpie_model for Windows

### DIFF
--- a/R/compile.R
+++ b/R/compile.R
@@ -117,7 +117,7 @@ nutpie_compile_model <- function(stan_file = NULL, code = NULL,
 #' @export
 print.nutpie_model <- function(x, ...) {
   cat("nutpie Stan model\n")
-  src <- if (is.na(x$stan_file)) "<inline code>" else x$stan_file
+  src <- if (is.na(x$stan_file)) "<inline code>" else normalizePath(x$stan_file, mustWork = FALSE)
   cat("  Source: ", src, "\n")
   cat("  Library:", x$lib_path, "\n")
   invisible(x)


### PR DESCRIPTION
## Summary

- `canonical_path()` stores paths with forward slashes (`winslash = "/"`) for internal consistency in hashing
- `print.nutpie_model` was displaying the stored path verbatim, so Windows users saw `/`-separated paths
- The R-universe Windows CI test (`test-compile-cache.R:487`) compared against `normalizePath(stan)` (which returns backslashes on Windows), causing the mismatch and test failure
- Fix: call `normalizePath(..., mustWork = FALSE)` in `print.nutpie_model` to convert to OS-native separators at display time

## Test plan

- [ ] Verify Windows R-release/R-devel/R-oldrel jobs pass on R-universe CI
- [ ] Confirm macOS/Linux builds still pass (no change in behavior on those platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)