### PR TITLE
fix: graceful interrupt handling for mid-sampling stop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,9 @@ Imports:
     posterior
 Suggests:
     bayesplot,
+    cli,
     posteriordb,
+    progressr,
     reticulate,
     testthat (>= 3.0.0),
     withr

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -52,10 +52,12 @@ compile_stan_model <- function(stan_file, stanc_args, compile_args) .Call(wrap__
 #'   when expanding each draw. Setting this `FALSE` skips the GQ block
 #'   (including any `*_rng` calls) entirely. Must imply `include_tp = TRUE`
 #'   when `TRUE`, since GQ may reference TP.
+#' @param progress_callback NULL or an R closure invoked on each poll wakeup
+#'   with one argument: a list of per-chain progress snapshots.
 #' @return A named list with draws matrix, num_warmup, num_chains, diagnostics,
 #'   sampler_config (JSON), and optionally warmup_draws and warmup_diagnostics.
 #' @noRd
-sample_stan <- function(handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, extra_doublings, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq) .Call(wrap__sample_stan, handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, extra_doublings, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq)
+sample_stan <- function(handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, extra_doublings, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq, progress_callback) .Call(wrap__sample_stan, handle, num_draws, num_warmup, num_chains, seed, refresh, init_positions, jitter, save_warmup, num_cores, store_divergences, store_mass_matrix, store_unconstrained, store_gradient, adaptation, max_treedepth, mindepth, target_accept, max_energy_error, extra_doublings, mass_matrix_gamma, eigval_cutoff, keep_indices, include_tp, include_gq, progress_callback)
 
 #' Open a BridgeStan model and return an `ExternalPtr<BSHandle>` that caches
 #' parameter-name metadata. The handle may be used by any of the `bs_*`

--- a/R/progress.R
+++ b/R/progress.R
@@ -1,0 +1,307 @@
+#' @noRd
+in_with_progress <- function() {
+  if (!requireNamespace("progressr", quietly = TRUE)) return(FALSE)
+  target <- progressr::with_progress
+  for (i in seq_len(sys.nframe())) {
+    if (identical(sys.function(i), target)) return(TRUE)
+  }
+  FALSE
+}
+
+#' @noRd
+should_use_cli_progress <- function() {
+  interactive() && requireNamespace("cli", quietly = TRUE)
+}
+
+#' @noRd
+resolve_progress_mode <- function(progress, refresh) {
+  if (isTRUE(refresh <= 0L) || identical(progress, "none")) return("none")
+  switch(
+    progress,
+    "auto" = if (should_use_cli_progress()) "cli" else "text",
+    "cli" = {
+      if (!requireNamespace("cli", quietly = TRUE)) {
+        stop("`progress = \"cli\"` requires the 'cli' package. ",
+             "Install it or set `progress = \"text\"`.", call. = FALSE)
+      }
+      "cli"
+    },
+    "progressr" = {
+      if (!requireNamespace("progressr", quietly = TRUE)) {
+        stop("`progress = \"progressr\"` requires the 'progressr' package. ",
+             "Install it or set `progress = \"cli\"`/`\"text\"`.", call. = FALSE)
+      }
+      "progressr"
+    },
+    "text" = "text",
+    "none" = "none"
+  )
+}
+
+#' @noRd
+as_progress_num <- function(x, default = 0) {
+  if (is.null(x) || length(x) == 0L || is.na(x)) return(default)
+  as.numeric(x)
+}
+
+#' @noRd
+format_progress_time <- function(seconds) {
+  seconds <- as_progress_num(seconds, 0)
+  if (!is.finite(seconds) || seconds < 0) seconds <- 0
+  if (seconds < 60) return(sprintf("%.1fs", seconds))
+  mins <- floor(seconds / 60)
+  secs <- round(seconds %% 60)
+  if (mins < 60) return(sprintf("%dm%02ds", mins, secs))
+  hours <- floor(mins / 60)
+  mins <- mins %% 60
+  sprintf("%dh%02dm", hours, mins)
+}
+
+#' @noRd
+summarize_progress_snapshot <- function(snapshot) {
+  if (length(snapshot) == 0L) {
+    return(list(
+      total_finished = 0, total_draws = 0, phase = "warmup",
+      total_divergences = 0L, slowest_chain = NA_integer_,
+      min_step_size = NA_real_, max_latest_num_steps = NA_integer_,
+      avg_num_steps = NA_real_, first_divergence = NA_character_,
+      max_runtime = 0, status = "waiting for chains"
+    ))
+  }
+
+  finished <- vapply(snapshot, function(s) as_progress_num(s$finished_draws), numeric(1))
+  totals <- vapply(snapshot, function(s) as_progress_num(s$total_draws), numeric(1))
+  divergences <- vapply(snapshot, function(s) as.integer(as_progress_num(s$divergences)), integer(1))
+  tuning <- vapply(snapshot, function(s) isTRUE(s$tuning), logical(1))
+  steps <- vapply(snapshot, function(s) as.integer(as_progress_num(s$latest_num_steps)), integer(1))
+  total_steps <- vapply(snapshot, function(s) as_progress_num(s$total_num_steps), numeric(1))
+  step_sizes <- vapply(snapshot, function(s) as_progress_num(s$step_size, NA_real_), numeric(1))
+  runtimes <- vapply(snapshot, function(s) as_progress_num(s$runtime), numeric(1))
+  chains <- seq_along(snapshot)
+  chain_values <- vapply(snapshot, function(s) as.integer(as_progress_num(s$chain, NA_real_)), integer(1))
+  chains[!is.na(chain_values)] <- chain_values[!is.na(chain_values)]
+
+  progress_ratio <- ifelse(totals > 0, finished / totals, 1)
+  slowest <- chains[which.min(progress_ratio)]
+  finite_steps <- step_sizes[is.finite(step_sizes) & step_sizes > 0]
+  min_step <- if (length(finite_steps) > 0L) min(finite_steps) else NA_real_
+  avg_steps <- if (sum(finished) > 0) sum(total_steps) / sum(finished) else NA_real_
+
+  first_div <- NA_character_
+  div_chains <- which(divergences > 0L)
+  if (length(div_chains) > 0L) {
+    candidates <- lapply(div_chains, function(i) {
+      draws <- snapshot[[i]]$divergent_draws
+      if (is.null(draws) || length(draws) == 0L) return(NULL)
+      list(chain = chains[i], draw = min(as.integer(draws)))
+    })
+    candidates <- Filter(Negate(is.null), candidates)
+    if (length(candidates) > 0L) {
+      draws <- vapply(candidates, `[[`, integer(1), "draw")
+      first <- candidates[[which.min(draws)]]
+      first_div <- sprintf("chain %d draw %d", first$chain, first$draw)
+    }
+  }
+
+  phase <- if (all(tuning)) {
+    "warmup"
+  } else if (any(tuning)) {
+    "mixed"
+  } else {
+    "sample"
+  }
+  total_divergences <- sum(divergences)
+  total_finished <- sum(finished)
+  total_draws <- sum(totals)
+  max_latest_steps <- if (length(steps) > 0L) max(steps) else NA_integer_
+  max_runtime <- if (length(runtimes) > 0L) max(runtimes) else 0
+
+  slowest_idx <- which(chains == slowest)[1]
+  diag_bits <- c(
+    phase,
+    sprintf("c%d %d/%d", slowest, finished[slowest_idx], totals[slowest_idx])
+  )
+  if (is.finite(min_step)) diag_bits <- c(diag_bits, sprintf("step %.3g", min_step))
+  if (is.finite(avg_steps)) diag_bits <- c(diag_bits, sprintf("lf %.1f avg", avg_steps))
+  diag_bits <- c(diag_bits, sprintf("lf %d max", max_latest_steps))
+  if (total_divergences > 0L) {
+    div_msg <- sprintf("div %d", total_divergences)
+    if (!is.na(first_div)) div_msg <- paste0(div_msg, " first ", first_div)
+    diag_bits <- c(div_msg, diag_bits)
+  }
+
+  list(
+    total_finished = total_finished,
+    total_draws = total_draws,
+    phase = phase,
+    total_divergences = total_divergences,
+    slowest_chain = slowest,
+    min_step_size = min_step,
+    max_latest_num_steps = max_latest_steps,
+    avg_num_steps = avg_steps,
+    first_divergence = first_div,
+    max_runtime = max_runtime,
+    status = paste(diag_bits, collapse = " | ")
+  )
+}
+
+#' @noRd
+print_progress_summary <- function(summary, snapshot, elapsed = NULL) {
+  if (is.null(summary) || length(snapshot) == 0L) return(invisible(NULL))
+  elapsed <- elapsed %||% summary$max_runtime
+  message("Sampling complete in ", format_progress_time(elapsed))
+
+  rows <- lapply(snapshot, function(s) {
+    finished <- as_progress_num(s$finished_draws)
+    total_steps <- as_progress_num(s$total_num_steps)
+    avg_steps <- if (finished > 0) total_steps / finished else NA_real_
+    sprintf(
+      "  Chain %d: %d draws, %s, step %.3g, avg leapfrog %.1f, %d divergences",
+      as.integer(as_progress_num(s$chain, 0)),
+      as.integer(finished),
+      format_progress_time(as_progress_num(s$runtime)),
+      as_progress_num(s$step_size, NA_real_),
+      avg_steps,
+      as.integer(as_progress_num(s$divergences))
+    )
+  })
+  message(paste(rows, collapse = "\n"))
+  if (summary$total_divergences > 0L) {
+    message(
+      "Warning: ", summary$total_divergences,
+      " divergent transition", if (summary$total_divergences == 1L) "" else "s",
+      " after warmup. Try increasing `target_accept`, inspecting pairs, or reparameterizing."
+    )
+  }
+  invisible(NULL)
+}
+
+#' @noRd
+print_sampling_diagnostic_summary <- function(diagnostics, num_chains, elapsed) {
+  message("Sampling complete in ", format_progress_time(elapsed))
+  if (is.null(diagnostics) || length(diagnostics) == 0L || is.null(diagnostics$chain)) {
+    return(invisible(NULL))
+  }
+
+  chains <- sort(unique(as.integer(diagnostics$chain)))
+  rows <- lapply(chains, function(ch) {
+    idx <- as.integer(diagnostics$chain) == ch
+    n <- sum(idx)
+    step <- if (!is.null(diagnostics$step_size)) {
+      tail(stats::na.omit(as.numeric(diagnostics$step_size[idx])), 1)
+    } else {
+      numeric()
+    }
+    step <- if (length(step) == 0L) NA_real_ else step[1]
+    avg_leapfrog <- if (!is.null(diagnostics$n_steps)) {
+      mean(as.numeric(diagnostics$n_steps[idx]), na.rm = TRUE)
+    } else {
+      NA_real_
+    }
+    divs <- if (!is.null(diagnostics$diverging)) {
+      sum(as.logical(diagnostics$diverging[idx]), na.rm = TRUE)
+    } else {
+      0L
+    }
+    sprintf(
+      "  Chain %d: %d draws, step %.3g, avg leapfrog %.1f, %d divergences",
+      ch, n, step, avg_leapfrog, as.integer(divs)
+    )
+  })
+  message(paste(rows, collapse = "\n"))
+
+  total_divs <- if (!is.null(diagnostics$diverging)) {
+    sum(as.logical(diagnostics$diverging), na.rm = TRUE)
+  } else {
+    0L
+  }
+  if (total_divs > 0L) {
+    message(
+      "Warning: ", total_divs,
+      " divergent transition", if (total_divs == 1L) "" else "s",
+      " after warmup. Try increasing `target_accept`, inspecting pairs, or reparameterizing."
+    )
+  }
+  invisible(NULL)
+}
+
+#' @noRd
+make_cli_progress_callback <- function(num_chains, num_warmup, num_draws,
+                                       id = NULL,
+                                       update = NULL,
+                                       done = NULL) {
+  if (is.null(update)) update <- cli::cli_progress_update
+  if (is.null(done)) done <- cli::cli_progress_done
+  total_steps <- as.numeric(num_chains) * (as.numeric(num_warmup) + as.numeric(num_draws))
+  if (is.null(id)) {
+    id <- cli::cli_progress_bar(
+      name = "Sampling",
+      total = total_steps,
+      type = "custom",
+      clear = FALSE,
+      format = paste(
+        "{cli::pb_spin} Sampling {cli::pb_percent} |{cli::pb_bar}|",
+        "{cli::pb_current}/{cli::pb_total} draws {cli::pb_eta_str}",
+        "{cli::pb_status}"
+      ),
+      format_done = paste(
+        "Sampling {cli::pb_percent} |{cli::pb_bar}|",
+        "{cli::pb_current}/{cli::pb_total} draws",
+        "{cli::pb_status}"
+      ),
+      .auto_close = FALSE
+    )
+  }
+
+  last_total <- 0
+  last_status <- ""
+  last_summary <- NULL
+  last_snapshot <- NULL
+
+  callback_failed <- FALSE
+
+  callback <- function(snapshot) {
+    if (callback_failed) return(invisible(NULL))
+    summary <- summarize_progress_snapshot(snapshot)
+    last_summary <<- summary
+    last_snapshot <<- snapshot
+    total_now <- min(summary$total_finished, total_steps)
+    status <- summary$status
+    if (total_now == last_total && identical(status, last_status)) return(invisible(NULL))
+    last_total <<- total_now
+    last_status <<- status
+    ok <- try(update(set = total_now, status = status, id = id, force = TRUE), silent = TRUE)
+    if (inherits(ok, "try-error")) callback_failed <<- TRUE
+    invisible(NULL)
+  }
+
+  attr(callback, "finish") <- function() {
+    try(done(id = id), silent = TRUE)
+    invisible(NULL)
+  }
+  callback
+}
+
+#' @noRd
+make_progressr_callback <- function(num_chains, num_warmup, num_draws) {
+  total_steps <- as.numeric(num_chains) * (as.numeric(num_warmup) + as.numeric(num_draws))
+  p <- progressr::progressor(steps = total_steps, on_exit = FALSE)
+  last_total <- 0
+  last_status <- ""
+  function(snapshot) {
+    summary <- summarize_progress_snapshot(snapshot)
+    delta <- max(0, min(summary$total_finished, total_steps) - last_total)
+    last_total <<- min(summary$total_finished, total_steps)
+    if (delta == 0 && identical(summary$status, last_status)) return(invisible(NULL))
+    last_status <<- summary$status
+    p(amount = delta, message = summary$status)
+    invisible(NULL)
+  }
+}
+
+#' @noRd
+finish_progress_callback <- function(callback) {
+  finish <- attr(callback, "finish")
+  if (is.function(finish)) finish()
+  invisible(NULL)
+}

--- a/R/sample.R
+++ b/R/sample.R
@@ -26,8 +26,14 @@
 #' @param extra_doublings Number of additional tree doublings allowed after a
 #'   turning point is reached. Default `NULL` keeps the nuts-rs default
 #'   (currently 0).
-#' @param refresh How often to print progress updates, in draws per chain.
+#' @param refresh How often to print text progress updates, in draws per chain.
 #'   Set to `0` to suppress progress output. Default is `100`.
+#' @param progress Progress rendering mode. `"auto"` uses a `cli` progress bar
+#'   in interactive sessions when the `cli` package is installed, otherwise the
+#'   line-oriented text log. `"cli"` shows a compact sampler-aware bar,
+#'   `"progressr"` emits progressr signals for custom handlers, `"text"` prints
+#'   line-oriented updates, and `"none"` suppresses progress. `refresh = 0`
+#'   always disables progress.
 #' @param init Initial values for each chain. Single entry point that
 #'   dispatches on the input shape:
 #'   \describe{
@@ -154,6 +160,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
                           target_accept = NULL, max_energy_error = NULL,
                           extra_doublings = NULL,
                           refresh = 100L,
+                          progress = c("auto", "cli", "progressr", "text", "none"),
                           init = NULL,
                           init_mean = NULL,
                           save_warmup = FALSE, cores = NULL,
@@ -175,6 +182,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   }
   adaptation <- match.arg(adaptation)
   if (identical(adaptation, "low-rank")) adaptation <- "low_rank"
+  progress <- match.arg(progress)
   if (isTRUE(low_rank_modified_mass_matrix)) {
     warning(
       "`low_rank_modified_mass_matrix` is deprecated; use ",
@@ -203,32 +211,65 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
                                                flags$include_gq)
   keep_indices <- resolve_keep_indices(constrain_names, pars, include)
 
-  raw <- sample_stan(
-    handle,
-    num_draws,
-    num_warmup,
-    num_chains,
-    as.integer(seed),
-    as.integer(refresh),
-    init_resolved$positions,
-    isTRUE(init_resolved$jitter),
-    isTRUE(save_warmup),
-    cores,
-    isTRUE(store_divergences),
-    isTRUE(store_mass_matrix),
-    isTRUE(store_unconstrained),
-    isTRUE(store_gradient),
-    adaptation,
-    opt_double(max_treedepth, "max_treedepth"),
-    opt_double(mindepth, "mindepth"),
-    opt_double(target_accept, "target_accept"),
-    opt_double(max_energy_error, "max_energy_error"),
-    opt_double(extra_doublings, "extra_doublings"),
-    opt_double(mass_matrix_gamma, "mass_matrix_gamma"),
-    opt_double(mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"),
-    keep_indices,
-    isTRUE(flags$include_tp),
-    isTRUE(flags$include_gq)
+  resolved_progress <- resolve_progress_mode(progress, refresh)
+  effective_refresh <- switch(
+    resolved_progress,
+    "none" = 0L,
+    "text" = as.integer(refresh),
+    "cli" = 1L,
+    "progressr" = 1L
+  )
+
+  call_sample_stan <- function(progress_callback) {
+    sample_stan(
+      handle,
+      num_draws,
+      num_warmup,
+      num_chains,
+      as.integer(seed),
+      effective_refresh,
+      init_resolved$positions,
+      isTRUE(init_resolved$jitter),
+      isTRUE(save_warmup),
+      cores,
+      isTRUE(store_divergences),
+      isTRUE(store_mass_matrix),
+      isTRUE(store_unconstrained),
+      isTRUE(store_gradient),
+      adaptation,
+      opt_double(max_treedepth, "max_treedepth"),
+      opt_double(mindepth, "mindepth"),
+      opt_double(target_accept, "target_accept"),
+      opt_double(max_energy_error, "max_energy_error"),
+      opt_double(extra_doublings, "extra_doublings"),
+      opt_double(mass_matrix_gamma, "mass_matrix_gamma"),
+      opt_double(mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"),
+      keep_indices,
+      isTRUE(flags$include_tp),
+      isTRUE(flags$include_gq),
+      progress_callback
+    )
+  }
+
+  raw <- switch(
+    resolved_progress,
+    "cli" = {
+      progress_callback <- make_cli_progress_callback(num_chains, num_warmup, num_draws)
+      progress_started <- Sys.time()
+      on.exit(finish_progress_callback(progress_callback), add = TRUE)
+      raw <- call_sample_stan(progress_callback)
+      finish_progress_callback(progress_callback)
+      attr(raw, "progress_elapsed") <- as.numeric(difftime(Sys.time(), progress_started, units = "secs"))
+      raw
+    },
+    "progressr" = {
+      run_with_progressr <- function() {
+        progress_callback <- make_progressr_callback(num_chains, num_warmup, num_draws)
+        call_sample_stan(progress_callback)
+      }
+      if (in_with_progress()) run_with_progressr() else progressr::with_progress(run_with_progressr())
+    },
+    call_sample_stan(NULL)
   )
   draws <- matrix_to_draws_array(raw$draws, num_draws, num_chains)
   attr(draws, "diagnostics") <- reindex_diagnostics(raw$diagnostics,
@@ -237,6 +278,14 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   attr(draws, "num_warmup") <- num_warmup
   attr(draws, "num_draws") <- num_draws
   attr(draws, "sampler_config") <- rename_sampler_config(raw$sampler_config)
+
+  if (identical(resolved_progress, "cli")) {
+    print_sampling_diagnostic_summary(
+      attr(draws, "diagnostics"),
+      num_chains = num_chains,
+      elapsed = attr(raw, "progress_elapsed") %||% 0
+    )
+  }
 
   if (isTRUE(save_warmup) && !is.null(raw$warmup_draws)) {
     warmup <- matrix_to_draws_array(raw$warmup_draws, num_warmup, num_chains)

--- a/man/nutpie_sample.Rd
+++ b/man/nutpie_sample.Rd
@@ -17,6 +17,7 @@ nutpie_sample(
   max_energy_error = NULL,
   extra_doublings = NULL,
   refresh = 100L,
+  progress = c("auto", "cli", "progressr", "text", "none"),
   init = NULL,
   init_mean = NULL,
   save_warmup = FALSE,
@@ -71,8 +72,15 @@ is treated as a divergence. Default \code{NULL} keeps the nuts-rs default.}
 turning point is reached. Default \code{NULL} keeps the nuts-rs default
 (currently 0).}
 
-\item{refresh}{How often to print progress updates, in draws per chain.
+\item{refresh}{How often to print text progress updates, in draws per chain.
 Set to \code{0} to suppress progress output. Default is \code{100}.}
+
+\item{progress}{Progress rendering mode. \code{"auto"} uses a \code{cli} progress bar
+in interactive sessions when the \code{cli} package is installed, otherwise the
+line-oriented text log. \code{"cli"} shows a compact sampler-aware bar,
+\code{"progressr"} emits progressr signals for custom handlers, \code{"text"} prints
+line-oriented updates, and \code{"none"} suppresses progress. \code{refresh = 0}
+always disables progress.}
 
 \item{init}{Initial values for each chain. Single entry point that
 dispatches on the input shape:

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -5,8 +5,8 @@ use arrow::array::{
     StringArray, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::DataType;
-use extendr_api::prelude::*;
 use extendr_api::error::Result;
+use extendr_api::prelude::*;
 use nuts_rs::{
     ArrowConfig, ArrowTrace, ChainProgress, DiagNutsSettings, LowRankNutsSettings,
     ProgressCallback, Sampler, SamplerWaitResult, Settings,
@@ -101,6 +101,21 @@ fn compile_stan_model_impl(
     Ok(lib_path.to_string_lossy().into_owned())
 }
 
+#[derive(Clone, Default)]
+struct ChainState {
+    chain: usize,
+    finished_draws: usize,
+    total_draws: usize,
+    divergences: usize,
+    tuning: bool,
+    started: bool,
+    latest_num_steps: usize,
+    total_num_steps: usize,
+    step_size: f64,
+    runtime: Duration,
+    divergent_draws: Vec<usize>,
+}
+
 /// Sample from a Stan model using nuts-rs NUTS sampler.
 /// Run the sampler with progress reporting. Generic over Settings type.
 fn run_sampler<S: Settings>(
@@ -112,40 +127,39 @@ fn run_sampler<S: Settings>(
     num_cores: i32,
     refresh: i32,
     save_warmup: bool,
+    progress_cb: Option<Function>,
 ) -> Result<Vec<ArrowTrace>> {
-    let show_progress = refresh > 0;
     let refresh = refresh.max(0) as usize;
+    let mut progress_cb = progress_cb;
+    let use_callback = progress_cb.is_some();
+    let text_log = refresh > 0 && !use_callback;
+    let poll = text_log || use_callback;
 
-    #[derive(Clone, Default)]
-    struct ChainState {
-        finished_draws: usize,
-        total_draws: usize,
-        divergences: usize,
-        tuning: bool,
-        step_size: f64,
-    }
-
-    let progress_state: Arc<Mutex<Vec<ChainState>>> =
-        Arc::new(Mutex::new(Vec::new()));
+    let progress_state: Arc<Mutex<Vec<ChainState>>> = Arc::new(Mutex::new(Vec::new()));
     let state_clone = progress_state.clone();
 
-    let callback = if show_progress {
+    let callback = if poll {
         Some(ProgressCallback {
-            callback: Box::new(
-                move |_elapsed: Duration, progress: Box<[ChainProgress]>| {
-                    let snapshot: Vec<ChainState> = progress
-                        .iter()
-                        .map(|c| ChainState {
-                            finished_draws: c.finished_draws,
-                            total_draws: c.total_draws,
-                            divergences: c.divergences,
-                            tuning: c.tuning,
-                            step_size: c.step_size,
-                        })
-                        .collect();
-                    *state_clone.lock().unwrap() = snapshot;
-                },
-            ),
+            callback: Box::new(move |_elapsed: Duration, progress: Box<[ChainProgress]>| {
+                let snapshot: Vec<ChainState> = progress
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| ChainState {
+                        chain: i + 1,
+                        finished_draws: c.finished_draws,
+                        total_draws: c.total_draws,
+                        divergences: c.divergences,
+                        tuning: c.tuning,
+                        started: c.started,
+                        latest_num_steps: c.latest_num_steps,
+                        total_num_steps: c.total_num_steps,
+                        step_size: c.step_size,
+                        runtime: c.runtime,
+                        divergent_draws: c.divergent_draws.clone(),
+                    })
+                    .collect();
+                *state_clone.lock().unwrap() = snapshot;
+            }),
             rate: Duration::from_millis(100),
         })
     } else {
@@ -155,12 +169,22 @@ fn run_sampler<S: Settings>(
     let mut arrow_config = ArrowConfig::default();
     arrow_config.store_warmup = save_warmup;
     let mut sampler_opt = Some(
-        Sampler::new(stan_model, settings, arrow_config, num_cores as usize, callback)
-            .map_err(r_err)?,
+        Sampler::new(
+            stan_model,
+            settings,
+            arrow_config,
+            num_cores as usize,
+            callback,
+        )
+        .map_err(r_err)?,
     );
 
     let start = Instant::now();
-    let mut last_reported: Vec<usize> = vec![0; num_chains as usize];
+    let mut last_reported: Vec<usize> = if text_log {
+        vec![0; num_chains as usize]
+    } else {
+        Vec::new()
+    };
     let mut chain_announced: Vec<bool> = vec![false; num_chains as usize];
     let announce_finished = |i: usize| {
         rprintln!(
@@ -170,7 +194,7 @@ fn run_sampler<S: Settings>(
         );
     };
 
-    if show_progress {
+    if text_log {
         rprintln!(
             "Sampling {} chains, {} draws each ({} warmup)...\n",
             num_chains,
@@ -181,7 +205,7 @@ fn run_sampler<S: Settings>(
 
     let results = loop {
         let sampler = sampler_opt.take().unwrap();
-        let wait_dur = if show_progress {
+        let wait_dur = if poll {
             Duration::from_millis(200)
         } else {
             Duration::from_secs(600)
@@ -190,43 +214,70 @@ fn run_sampler<S: Settings>(
             SamplerWaitResult::Trace(traces) => break traces,
             SamplerWaitResult::Timeout(s) => {
                 sampler_opt = Some(s);
-                if show_progress {
+                let state_snapshot: Vec<ChainState> = {
                     let state = progress_state.lock().unwrap();
-                    if !state.is_empty() {
-                        for (i, chain) in state.iter().enumerate() {
-                            let draws_since = chain.finished_draws.saturating_sub(last_reported[i]);
-                            if draws_since >= refresh {
-                                let phase = if chain.tuning { "warmup" } else { "sample" };
-                                let elapsed = start.elapsed().as_secs_f64();
-                                if chain.divergences > 0 {
-                                    rprintln!(
-                                        "  Chain {} [{phase}] {}/{} draws ({} divergences, step size {:.3}) [{:.1}s]",
-                                        i + 1,
-                                        chain.finished_draws,
-                                        chain.total_draws,
-                                        chain.divergences,
-                                        chain.step_size,
-                                        elapsed
-                                    );
-                                } else {
-                                    rprintln!(
-                                        "  Chain {} [{phase}] {}/{} draws (step size {:.3}) [{:.1}s]",
-                                        i + 1,
-                                        chain.finished_draws,
-                                        chain.total_draws,
-                                        chain.step_size,
-                                        elapsed
-                                    );
-                                }
-                                last_reported[i] = chain.finished_draws;
+                    state.clone()
+                };
+                if state_snapshot.is_empty() {
+                    continue;
+                }
+
+                let cb_failed = if let Some(ref cb) = progress_cb {
+                    let snapshot_list = build_progress_snapshot(&state_snapshot);
+                    let pairlist = Pairlist::from_pairs([("", Robj::from(snapshot_list))]);
+                    match cb.call(pairlist) {
+                        Ok(_) => false,
+                        Err(e) => {
+                            rprintln!(
+                                "nutpieR: progress callback failed ({}); disabling further callbacks for this run.",
+                                e
+                            );
+                            true
+                        }
+                    }
+                } else {
+                    false
+                };
+                if cb_failed {
+                    progress_cb = None;
+                }
+
+                if text_log {
+                    for (i, chain) in state_snapshot.iter().enumerate() {
+                        let draws_since = chain.finished_draws.saturating_sub(last_reported[i]);
+                        if draws_since >= refresh {
+                            let phase = if chain.tuning { "warmup" } else { "sample" };
+                            let elapsed = start.elapsed().as_secs_f64();
+                            if chain.divergences > 0 {
+                                rprintln!(
+                                    "  Chain {} [{phase}] {}/{} draws ({} divergences, step size {:.3}, leapfrog {}) [{:.1}s]",
+                                    i + 1,
+                                    chain.finished_draws,
+                                    chain.total_draws,
+                                    chain.divergences,
+                                    chain.step_size,
+                                    chain.latest_num_steps,
+                                    elapsed
+                                );
+                            } else {
+                                rprintln!(
+                                    "  Chain {} [{phase}] {}/{} draws (step size {:.3}, leapfrog {}) [{:.1}s]",
+                                    i + 1,
+                                    chain.finished_draws,
+                                    chain.total_draws,
+                                    chain.step_size,
+                                    chain.latest_num_steps,
+                                    elapsed
+                                );
                             }
-                            if !chain_announced[i]
-                                && chain.total_draws > 0
-                                && chain.finished_draws >= chain.total_draws
-                            {
-                                announce_finished(i);
-                                chain_announced[i] = true;
-                            }
+                            last_reported[i] = chain.finished_draws;
+                        }
+                        if !chain_announced[i]
+                            && chain.total_draws > 0
+                            && chain.finished_draws >= chain.total_draws
+                        {
+                            announce_finished(i);
+                            chain_announced[i] = true;
                         }
                     }
                 }
@@ -235,7 +286,19 @@ fn run_sampler<S: Settings>(
         }
     };
 
-    if show_progress {
+    if let Some(ref cb) = progress_cb {
+        let state_snapshot: Vec<ChainState> = {
+            let state = progress_state.lock().unwrap();
+            state.clone()
+        };
+        if !state_snapshot.is_empty() {
+            let snapshot_list = build_progress_snapshot(&state_snapshot);
+            let pairlist = Pairlist::from_pairs([("", Robj::from(snapshot_list))]);
+            let _ = cb.call(pairlist);
+        }
+    }
+
+    if text_log {
         let total_divergences: usize = {
             let state = progress_state.lock().unwrap();
             for i in 0..state.len() {
@@ -264,6 +327,35 @@ fn run_sampler<S: Settings>(
     }
 
     Ok(results)
+}
+
+/// Build a `List` of per-chain named lists for the R progress callback.
+/// Field set must match the R-side progress helpers in `R/progress.R`.
+fn build_progress_snapshot(state: &[ChainState]) -> List {
+    let entries: Vec<Robj> = state
+        .iter()
+        .map(|c| {
+            list!(
+                chain = c.chain as i32,
+                finished_draws = c.finished_draws as i32,
+                total_draws = c.total_draws as i32,
+                divergences = c.divergences as i32,
+                tuning = c.tuning,
+                started = c.started,
+                latest_num_steps = c.latest_num_steps as i32,
+                total_num_steps = c.total_num_steps as f64,
+                step_size = c.step_size,
+                runtime = c.runtime.as_secs_f64(),
+                divergent_draws = c
+                    .divergent_draws
+                    .iter()
+                    .map(|x| *x as i32)
+                    .collect::<Vec<i32>>()
+            )
+            .into_robj()
+        })
+        .collect();
+    List::from_values(entries)
 }
 
 /// @param handle An `ExternalPtr<BSHandle>` from `bs_open()`.
@@ -304,6 +396,13 @@ fn run_sampler<S: Settings>(
 ///   when expanding each draw. Setting this `FALSE` skips the GQ block
 ///   (including any `*_rng` calls) entirely. Must imply `include_tp = TRUE`
 ///   when `TRUE`, since GQ may reference TP.
+/// @param progress_callback NULL or an R closure invoked on each poll wakeup
+///   with one argument: a list of `num_chains` per-chain snapshots
+///   (`chain`, `finished_draws`, `total_draws`, `divergences`, `tuning`,
+///   `started`, `latest_num_steps`, `total_num_steps`, `step_size`, `runtime`,
+///   `divergent_draws`). When supplied, the built-in per-chain text log is
+///   suppressed; errors raised by the closure are warned once and further calls
+///   suppressed for the run.
 /// @return A named list with draws matrix, num_warmup, num_chains, diagnostics,
 ///   sampler_config (JSON), and optionally warmup_draws and warmup_diagnostics.
 /// @noRd
@@ -334,198 +433,229 @@ fn sample_stan(
     keep_indices: Robj,
     include_tp: bool,
     include_gq: bool,
+    progress_callback: Robj,
 ) -> List {
     or_throw((|| -> Result<List> {
-    // Defensive guards before unsigned casts. The R wrapper validates these
-    // already; we re-check here so direct callers (or malformed inputs that
-    // somehow slip past the R layer) can't turn negative ints into huge
-    // u64/usize allocations.
-    for (val, name) in [
-        (num_draws, "num_draws"),
-        (num_chains, "num_chains"),
-        (num_cores, "num_cores"),
-    ] {
-        if val <= 0 {
+        // Defensive guards before unsigned casts. The R wrapper validates these
+        // already; we re-check here so direct callers (or malformed inputs that
+        // somehow slip past the R layer) can't turn negative ints into huge
+        // u64/usize allocations.
+        for (val, name) in [
+            (num_draws, "num_draws"),
+            (num_chains, "num_chains"),
+            (num_cores, "num_cores"),
+        ] {
+            if val <= 0 {
+                return Err(Error::Other(format!("{} must be >= 1, got {}", name, val)));
+            }
+        }
+        if num_warmup < 0 {
             return Err(Error::Other(format!(
-                "{} must be >= 1, got {}",
-                name, val
+                "num_warmup must be >= 0, got {}",
+                num_warmup
             )));
         }
-    }
-    if num_warmup < 0 {
-        return Err(Error::Other(format!(
-            "num_warmup must be >= 0, got {}",
-            num_warmup
-        )));
-    }
-    check_seed(seed)?;
+        check_seed(seed)?;
 
-    let max_treedepth_opt = opt_count(&max_treedepth, "max_treedepth", 1)?;
-    let mindepth_opt = opt_count(&mindepth, "mindepth", 0)?;
-    let target_accept_opt =
-        opt_finite_in_open_unit(&target_accept, "target_accept")?;
-    let max_energy_error_opt = opt_finite_positive_f64(&max_energy_error, "max_energy_error")?;
-    let extra_doublings_opt = opt_count(&extra_doublings, "extra_doublings", 0)?;
+        let max_treedepth_opt = opt_count(&max_treedepth, "max_treedepth", 1)?;
+        let mindepth_opt = opt_count(&mindepth, "mindepth", 0)?;
+        let target_accept_opt = opt_finite_in_open_unit(&target_accept, "target_accept")?;
+        let max_energy_error_opt = opt_finite_positive_f64(&max_energy_error, "max_energy_error")?;
+        let extra_doublings_opt = opt_count(&extra_doublings, "extra_doublings", 0)?;
 
-    let init_positions_raw: Option<Vec<Vec<f64>>> = if init_positions.is_null() {
-        None
-    } else {
-        let lst = init_positions
-            .as_list()
-            .ok_or_else(|| Error::Other("init_positions must be a list of numeric vectors".into()))?;
-        let mut out = Vec::with_capacity(lst.len());
-        for (i, (_, el)) in lst.iter().enumerate() {
-            let v = el.as_real_vector().ok_or_else(|| {
-                Error::Other(format!(
-                    "init_positions[[{}]] must be a numeric vector",
-                    i + 1
-                ))
+        let init_positions_raw: Option<Vec<Vec<f64>>> = if init_positions.is_null() {
+            None
+        } else {
+            let lst = init_positions.as_list().ok_or_else(|| {
+                Error::Other("init_positions must be a list of numeric vectors".into())
             })?;
-            out.push(v);
+            let mut out = Vec::with_capacity(lst.len());
+            for (i, (_, el)) in lst.iter().enumerate() {
+                let v = el.as_real_vector().ok_or_else(|| {
+                    Error::Other(format!(
+                        "init_positions[[{}]] must be a numeric vector",
+                        i + 1
+                    ))
+                })?;
+                out.push(v);
+            }
+            Some(out)
+        };
+
+        let stan_model = model::StanModel::new(&handle)
+            .with_init_positions(init_positions_raw, jitter)
+            .and_then(|m| m.with_constrain_flags(&handle, include_tp, include_gq))
+            .map_err(r_err)?;
+
+        let ndim = stan_model.num_constrained();
+        let all_param_names: &[String] = stan_model.constrained_param_names();
+
+        // Resolve keep_indices: NULL → keep all, else use as-supplied. Indices
+        // are 0-based and must be within [0, ndim).
+        let keep_cols: Vec<usize> = if keep_indices.is_null() {
+            (0..ndim).collect()
+        } else {
+            let v = keep_indices.as_integer_vector().ok_or_else(|| {
+                Error::Other("keep_indices must be NULL or an integer vector".into())
+            })?;
+            let mut out = Vec::with_capacity(v.len());
+            for &idx in v.iter() {
+                if idx < 0 || (idx as usize) >= ndim {
+                    return Err(Error::Other(format!(
+                        "keep_indices contains out-of-range value {} (ndim={})",
+                        idx, ndim
+                    )));
+                }
+                out.push(idx as usize);
+            }
+            out
+        };
+        let kept_param_names: Vec<String> = keep_cols
+            .iter()
+            .map(|&i| all_param_names[i].clone())
+            .collect();
+        let expand_error_count = stan_model.expand_error_count_handle();
+
+        let num_tune = num_warmup as usize;
+        let n_draws_per_chain = num_draws as usize;
+
+        macro_rules! configure_settings {
+            ($settings:expr) => {{
+                $settings.num_tune = num_warmup as u64;
+                $settings.num_draws = num_draws as u64;
+                $settings.num_chains = num_chains as usize;
+                $settings.seed = seed as u64;
+                if let Some(v) = max_treedepth_opt {
+                    $settings.maxdepth = v as u64;
+                }
+                if let Some(v) = mindepth_opt {
+                    $settings.mindepth = v as u64;
+                }
+                if let Some(v) = target_accept_opt {
+                    $settings.adapt_options.step_size_settings.target_accept = v;
+                }
+                if let Some(v) = max_energy_error_opt {
+                    $settings.max_energy_error = v;
+                }
+                if let Some(v) = extra_doublings_opt {
+                    $settings.extra_doublings = v as u64;
+                }
+                $settings.store_divergences = store_divergences;
+                $settings.store_unconstrained = store_unconstrained;
+                $settings.store_gradient = store_gradient;
+                $settings
+                    .adapt_options
+                    .mass_matrix_options
+                    .store_mass_matrix = store_mass_matrix;
+            }};
         }
-        Some(out)
-    };
 
-    let stan_model = model::StanModel::new(&handle)
-        .with_init_positions(init_positions_raw, jitter)
-        .and_then(|m| m.with_constrain_flags(&handle, include_tp, include_gq))
-        .map_err(r_err)?;
+        let progress_callback = if progress_callback.is_null() {
+            None
+        } else {
+            Some(progress_callback.as_function().ok_or_else(|| {
+                Error::Other("progress_callback must be NULL or a function".into())
+            })?)
+        };
 
-    let ndim = stan_model.num_constrained();
-    let all_param_names: &[String] = stan_model.constrained_param_names();
-
-    // Resolve keep_indices: NULL → keep all, else use as-supplied. Indices
-    // are 0-based and must be within [0, ndim).
-    let keep_cols: Vec<usize> = if keep_indices.is_null() {
-        (0..ndim).collect()
-    } else {
-        let v = keep_indices
-            .as_integer_vector()
-            .ok_or_else(|| Error::Other("keep_indices must be NULL or an integer vector".into()))?;
-        let mut out = Vec::with_capacity(v.len());
-        for &idx in v.iter() {
-            if idx < 0 || (idx as usize) >= ndim {
+        let (results, sampler_config_json) = match adaptation {
+            "low_rank" => {
+                let mut settings = LowRankNutsSettings::default();
+                configure_settings!(settings);
+                if let Some(v) = opt_finite_positive_f64(&mass_matrix_gamma, "mass_matrix_gamma")? {
+                    settings.adapt_options.mass_matrix_options.gamma = v;
+                }
+                if let Some(v) = opt_finite_positive_f64(&eigval_cutoff, "eigval_cutoff")? {
+                    settings.adapt_options.mass_matrix_options.eigval_cutoff = v;
+                }
+                run_with_settings(
+                    stan_model,
+                    settings,
+                    num_chains,
+                    num_draws,
+                    num_warmup,
+                    num_cores,
+                    refresh,
+                    save_warmup,
+                    progress_callback.clone(),
+                )?
+            }
+            "diag" => {
+                let mut settings = DiagNutsSettings::default();
+                configure_settings!(settings);
+                run_with_settings(
+                    stan_model,
+                    settings,
+                    num_chains,
+                    num_draws,
+                    num_warmup,
+                    num_cores,
+                    refresh,
+                    save_warmup,
+                    progress_callback.clone(),
+                )?
+            }
+            other => {
                 return Err(Error::Other(format!(
-                    "keep_indices contains out-of-range value {} (ndim={})",
-                    idx, ndim
+                    "adaptation must be one of \"diag\" or \"low_rank\", got \"{}\"",
+                    other
                 )));
             }
-            out.push(idx as usize);
+        };
+
+        let post_warmup_skip = if save_warmup { num_tune } else { 0 };
+
+        let draws_robj = build_draws_matrix(
+            &results,
+            &keep_cols,
+            post_warmup_skip,
+            n_draws_per_chain,
+            &kept_param_names,
+        )?;
+
+        // Diagnostic columns to suppress at the R boundary. nuts-rs 0.17.4
+        // populates `unconstrained_draw` and `gradient` unconditionally
+        // regardless of `store_unconstrained` / `store_gradient` (the flags
+        // exist but are not read in `chain.rs::extract_stats`). To match the
+        // documented R-side semantics — and to avoid surfacing one
+        // `ndim_unc`-wide list-of-vectors per draw by default — drop those
+        // columns here unless the user opts in. When nuts-rs starts honouring
+        // the flags, the columns will already be all-null and our existing
+        // `any_non_null` filter will drop them.
+        let mut drop_cols: Vec<&str> = Vec::new();
+        if !store_unconstrained {
+            drop_cols.push("unconstrained_draw");
         }
-        out
-    };
-    let kept_param_names: Vec<String> =
-        keep_cols.iter().map(|&i| all_param_names[i].clone()).collect();
-    let expand_error_count = stan_model.expand_error_count_handle();
-
-    let num_tune = num_warmup as usize;
-    let n_draws_per_chain = num_draws as usize;
-
-    macro_rules! configure_settings {
-        ($settings:expr) => {{
-            $settings.num_tune = num_warmup as u64;
-            $settings.num_draws = num_draws as u64;
-            $settings.num_chains = num_chains as usize;
-            $settings.seed = seed as u64;
-            if let Some(v) = max_treedepth_opt {
-                $settings.maxdepth = v as u64;
-            }
-            if let Some(v) = mindepth_opt {
-                $settings.mindepth = v as u64;
-            }
-            if let Some(v) = target_accept_opt {
-                $settings.adapt_options.step_size_settings.target_accept = v;
-            }
-            if let Some(v) = max_energy_error_opt {
-                $settings.max_energy_error = v;
-            }
-            if let Some(v) = extra_doublings_opt {
-                $settings.extra_doublings = v as u64;
-            }
-            $settings.store_divergences = store_divergences;
-            $settings.store_unconstrained = store_unconstrained;
-            $settings.store_gradient = store_gradient;
-            $settings.adapt_options.mass_matrix_options.store_mass_matrix = store_mass_matrix;
-        }};
-    }
-
-    let (results, sampler_config_json) = match adaptation {
-        "low_rank" => {
-            let mut settings = LowRankNutsSettings::default();
-            configure_settings!(settings);
-            if let Some(v) = opt_finite_positive_f64(&mass_matrix_gamma, "mass_matrix_gamma")? {
-                settings.adapt_options.mass_matrix_options.gamma = v;
-            }
-            if let Some(v) = opt_finite_positive_f64(&eigval_cutoff, "eigval_cutoff")? {
-                settings.adapt_options.mass_matrix_options.eigval_cutoff = v;
-            }
-            run_with_settings(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh, save_warmup)?
+        if !store_gradient {
+            drop_cols.push("gradient");
         }
-        "diag" => {
-            let mut settings = DiagNutsSettings::default();
-            configure_settings!(settings);
-            run_with_settings(stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh, save_warmup)?
-        }
-        other => {
-            return Err(Error::Other(format!(
-                "adaptation must be one of \"diag\" or \"low_rank\", got \"{}\"",
-                other
-            )));
-        }
-    };
 
-    let post_warmup_skip = if save_warmup { num_tune } else { 0 };
+        let diagnostics =
+            extract_diagnostics(&results, post_warmup_skip, n_draws_per_chain, &drop_cols)?;
 
-    let draws_robj = build_draws_matrix(
-        &results,
-        &keep_cols,
-        post_warmup_skip,
-        n_draws_per_chain,
-        &kept_param_names,
-    )?;
+        let warmup_draws_robj: Robj = if save_warmup {
+            build_draws_matrix(&results, &keep_cols, 0, num_tune, &kept_param_names)?
+        } else {
+            ().into_robj()
+        };
+        let warmup_diagnostics_robj: Robj = if save_warmup {
+            extract_diagnostics(&results, 0, num_tune, &drop_cols)?.into_robj()
+        } else {
+            ().into_robj()
+        };
 
-    // Diagnostic columns to suppress at the R boundary. nuts-rs 0.17.4
-    // populates `unconstrained_draw` and `gradient` unconditionally
-    // regardless of `store_unconstrained` / `store_gradient` (the flags
-    // exist but are not read in `chain.rs::extract_stats`). To match the
-    // documented R-side semantics — and to avoid surfacing one
-    // `ndim_unc`-wide list-of-vectors per draw by default — drop those
-    // columns here unless the user opts in. When nuts-rs starts honouring
-    // the flags, the columns will already be all-null and our existing
-    // `any_non_null` filter will drop them.
-    let mut drop_cols: Vec<&str> = Vec::new();
-    if !store_unconstrained {
-        drop_cols.push("unconstrained_draw");
-    }
-    if !store_gradient {
-        drop_cols.push("gradient");
-    }
+        let n_expand_errors = expand_error_count.load(Ordering::Relaxed) as i32;
 
-    let diagnostics = extract_diagnostics(&results, post_warmup_skip, n_draws_per_chain, &drop_cols)?;
-
-    let warmup_draws_robj: Robj = if save_warmup {
-        build_draws_matrix(&results, &keep_cols, 0, num_tune, &kept_param_names)?
-    } else {
-        ().into_robj()
-    };
-    let warmup_diagnostics_robj: Robj = if save_warmup {
-        extract_diagnostics(&results, 0, num_tune, &drop_cols)?.into_robj()
-    } else {
-        ().into_robj()
-    };
-
-    let n_expand_errors = expand_error_count.load(Ordering::Relaxed) as i32;
-
-    Ok(list!(
-        draws = draws_robj,
-        num_warmup = num_warmup,
-        num_chains = num_chains,
-        diagnostics = diagnostics,
-        warmup_draws = warmup_draws_robj,
-        warmup_diagnostics = warmup_diagnostics_robj,
-        expand_errors = n_expand_errors,
-        sampler_config = sampler_config_json
-    ))
+        Ok(list!(
+            draws = draws_robj,
+            num_warmup = num_warmup,
+            num_chains = num_chains,
+            diagnostics = diagnostics,
+            warmup_draws = warmup_draws_robj,
+            warmup_diagnostics = warmup_diagnostics_robj,
+            expand_errors = n_expand_errors,
+            sampler_config = sampler_config_json
+        ))
     })())
 }
 
@@ -559,21 +689,32 @@ fn opt_finite_in_open_unit(robj: &Robj, name: &str) -> Result<Option<f64>> {
     let v = opt_finite_f64(robj, name)?;
     if let Some(x) = v {
         if !(x > 0.0 && x < 1.0) {
-            return Err(Error::Other(format!("`{}` must be in (0, 1), got {}.", name, x)));
+            return Err(Error::Other(format!(
+                "`{}` must be in (0, 1), got {}.",
+                name, x
+            )));
         }
     }
     Ok(v)
 }
 
 fn opt_count(robj: &Robj, name: &str, min: i32) -> Result<Option<i32>> {
-    let Some(v) = opt_finite_f64(robj, name)? else { return Ok(None); };
+    let Some(v) = opt_finite_f64(robj, name)? else {
+        return Ok(None);
+    };
     if v.fract() != 0.0 {
-        return Err(Error::Other(format!("`{}` must be a whole number, got {}.", name, v)));
+        return Err(Error::Other(format!(
+            "`{}` must be a whole number, got {}.",
+            name, v
+        )));
     }
     if v < min as f64 || v > i32::MAX as f64 {
         return Err(Error::Other(format!(
             "`{}` must be in [{}, {}], got {}.",
-            name, min, i32::MAX, v
+            name,
+            min,
+            i32::MAX,
+            v
         )));
     }
     Ok(Some(v as i32))
@@ -590,11 +731,20 @@ fn run_with_settings<S: Settings + serde::Serialize>(
     num_cores: i32,
     refresh: i32,
     save_warmup: bool,
+    progress_callback: Option<Function>,
 ) -> Result<(Vec<ArrowTrace>, String)> {
     let json = serde_json::to_string(&settings)
         .map_err(|e| Error::Other(format!("failed to serialize sampler settings: {}", e)))?;
     let traces = run_sampler(
-        stan_model, settings, num_chains, num_draws, num_warmup, num_cores, refresh, save_warmup,
+        stan_model,
+        settings,
+        num_chains,
+        num_draws,
+        num_warmup,
+        num_cores,
+        refresh,
+        save_warmup,
+        progress_callback,
     )?;
     Ok((traces, json))
 }
@@ -771,10 +921,8 @@ fn column_to_robj(
         }
         DataType::Float64 => build_doubles!(Float64Array),
         DataType::Float32 => build_doubles!(Float32Array),
-        DataType::Int64 => build_int_or_double!(
-            Int64Array,
-            |v: i64| v > i32::MIN as i64 && v <= i32::MAX as i64
-        ),
+        DataType::Int64 => build_int_or_double!(Int64Array, |v: i64| v > i32::MIN as i64
+            && v <= i32::MAX as i64),
         DataType::UInt64 => build_int_or_double!(UInt64Array, |v: u64| v <= i32::MAX as u64),
         DataType::Int32 => build_int_or_double!(Int32Array, |v: i32| v > i32::MIN),
         DataType::UInt32 => build_int_or_double!(UInt32Array, |v: u32| v <= i32::MAX as u32),
@@ -824,7 +972,9 @@ fn column_to_robj(
                             // forward; `inner_values` outlives the loop, so
                             // a usize is enough — no per-row Vec clone.
                             let mut last_start: Option<usize> = if carry_forward {
-                                (0..skip).rev().find(|&r| !arr.is_null(r))
+                                (0..skip)
+                                    .rev()
+                                    .find(|&r| !arr.is_null(r))
                                     .map(|r| offsets[r] as usize)
                             } else {
                                 None
@@ -857,11 +1007,8 @@ fn column_to_robj(
                             }
                         }
                         let mut robj: Robj = out.into();
-                        robj.set_attrib(
-                            "dim",
-                            [total as i32, inner_len as i32].into_robj(),
-                        )
-                        .ok()?;
+                        robj.set_attrib("dim", [total as i32, inner_len as i32].into_robj())
+                            .ok()?;
                         return Some(robj);
                     }
                 }
@@ -942,9 +1089,9 @@ fn extract_diagnostics(
             "mass_matrix_inv" | "mass_matrix_eigvals" | "mass_matrix_stds"
         );
         let non_null_start = if carry_forward { 0 } else { skip };
-        let any_non_null = cols.iter().any(|c| {
-            (non_null_start..skip + n_draws).any(|row| row < c.len() && !c.is_null(row))
-        });
+        let any_non_null = cols
+            .iter()
+            .any(|c| (non_null_start..skip + n_draws).any(|row| row < c.len() && !c.is_null(row)));
         if !any_non_null {
             continue;
         }
@@ -1034,10 +1181,7 @@ fn bs_ndim_block(handle: ExternalPtr<model::BSHandle>) -> i32 {
 /// space. No JSON parsing.
 /// @noRd
 #[extendr]
-fn bs_param_unconstrain(
-    handle: ExternalPtr<model::BSHandle>,
-    theta: Vec<f64>,
-) -> Vec<f64> {
+fn bs_param_unconstrain(handle: ExternalPtr<model::BSHandle>, theta: Vec<f64>) -> Vec<f64> {
     or_throw(bs_param_unconstrain_impl(handle, theta))
 }
 
@@ -1101,10 +1245,7 @@ fn bs_param_constrain_impl(
 /// right primitive for resolving partial-init random fills.
 /// @noRd
 #[extendr]
-fn bs_param_constrain_block(
-    handle: ExternalPtr<model::BSHandle>,
-    theta_unc: Vec<f64>,
-) -> Vec<f64> {
+fn bs_param_constrain_block(handle: ExternalPtr<model::BSHandle>, theta_unc: Vec<f64>) -> Vec<f64> {
     or_throw(bs_param_constrain_block_impl(handle, theta_unc))
 }
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -214,6 +214,11 @@ fn run_sampler<S: Settings>(
             SamplerWaitResult::Trace(traces) => break traces,
             SamplerWaitResult::Timeout(s) => {
                 sampler_opt = Some(s);
+                // Check interrupt BEFORE calling back into R. If we call R first,
+                // R's evaluator may consume the interrupt flag internally (throwing
+                // an Err) and by the time we reach R_CheckUserInterrupt() below the
+                // flag is already cleared — sampling never stops.
+                unsafe { R_CheckUserInterrupt() };
                 let state_snapshot: Vec<ChainState> = {
                     let state = progress_state.lock().unwrap();
                     state.clone()
@@ -281,11 +286,6 @@ fn run_sampler<S: Settings>(
                         }
                     }
                 }
-                // Check for a pending R interrupt (e.g. Stop button in IDE). R's SIGINT
-                // handler only sets a flag; the longjmp happens here at a safe point where
-                // no Rust resources are mid-use. Without this, the async longjmp can fire
-                // inside wait_timeout and skip Rust destructors, crashing the session.
-                unsafe { R_CheckUserInterrupt() };
             }
             SamplerWaitResult::Err(e, _) => return Err(r_err(e)),
         }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -16,6 +16,10 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+extern "C" {
+    fn R_CheckUserInterrupt();
+}
+
 mod model;
 
 /// Convert any Display error to an extendr Error. Uses anyhow's alternate
@@ -205,11 +209,7 @@ fn run_sampler<S: Settings>(
 
     let results = loop {
         let sampler = sampler_opt.take().unwrap();
-        let wait_dur = if poll {
-            Duration::from_millis(200)
-        } else {
-            Duration::from_secs(600)
-        };
+        let wait_dur = Duration::from_millis(200);
         match sampler.wait_timeout(wait_dur) {
             SamplerWaitResult::Trace(traces) => break traces,
             SamplerWaitResult::Timeout(s) => {
@@ -281,6 +281,11 @@ fn run_sampler<S: Settings>(
                         }
                     }
                 }
+                // Check for a pending R interrupt (e.g. Stop button in IDE). R's SIGINT
+                // handler only sets a flag; the longjmp happens here at a safe point where
+                // no Rust resources are mid-use. Without this, the async longjmp can fire
+                // inside wait_timeout and skip Rust destructors, crashing the session.
+                unsafe { R_CheckUserInterrupt() };
             }
             SamplerWaitResult::Err(e, _) => return Err(r_err(e)),
         }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 extern "C" {
-    fn R_CheckUserInterrupt();
+    static mut R_interrupts_pending: std::os::raw::c_int;
 }
 
 mod model;
@@ -214,11 +214,15 @@ fn run_sampler<S: Settings>(
             SamplerWaitResult::Trace(traces) => break traces,
             SamplerWaitResult::Timeout(s) => {
                 sampler_opt = Some(s);
-                // Check interrupt BEFORE calling back into R. If we call R first,
-                // R's evaluator may consume the interrupt flag internally (throwing
-                // an Err) and by the time we reach R_CheckUserInterrupt() below the
-                // flag is already cleared — sampling never stops.
-                unsafe { R_CheckUserInterrupt() };
+                // Check interrupt BEFORE calling back into R. Clear the flag and
+                // return a normal Err so extendr raises a clean R error at the
+                // call site ("Sampling interrupted."), rather than longjmp'ing past
+                // the assignment and leaving the user with a confusing "object not
+                // found" on the next line.
+                if unsafe { R_interrupts_pending != 0 } {
+                    unsafe { R_interrupts_pending = 0 };
+                    return Err(Error::Other("Sampling interrupted.".into()));
+                }
                 let state_snapshot: Vec<ChainState> = {
                     let state = progress_state.lock().unwrap();
                     state.clone()

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -1,0 +1,130 @@
+test_that("progress mode resolves to cli in interactive auto mode", {
+  testthat::local_mocked_bindings(
+    interactive = function() TRUE,
+    .package = "base"
+  )
+  skip_if_not_installed("cli")
+
+  expect_equal(nutpieR:::resolve_progress_mode("auto", refresh = 100L), "cli")
+  expect_equal(nutpieR:::resolve_progress_mode("auto", refresh = 0L), "none")
+  expect_equal(nutpieR:::resolve_progress_mode("none", refresh = 100L), "none")
+})
+
+test_that("progress mode falls back to text outside interactive sessions", {
+  testthat::local_mocked_bindings(
+    interactive = function() FALSE,
+    .package = "base"
+  )
+
+  expect_equal(nutpieR:::resolve_progress_mode("auto", refresh = 100L), "text")
+})
+
+test_that("progress snapshot summary exposes useful sampler diagnostics", {
+  snapshot <- list(
+    list(
+      chain = 1L, finished_draws = 120L, total_draws = 200L,
+      divergences = 0L, tuning = TRUE, started = TRUE,
+      latest_num_steps = 15L, total_num_steps = 900L,
+      step_size = 0.12, runtime = 3.2,
+      divergent_draws = integer()
+    ),
+    list(
+      chain = 2L, finished_draws = 90L, total_draws = 200L,
+      divergences = 2L, tuning = FALSE, started = TRUE,
+      latest_num_steps = 63L, total_num_steps = 1800L,
+      step_size = 0.015, runtime = 4.1,
+      divergent_draws = c(17L, 88L)
+    )
+  )
+
+  summary <- nutpieR:::summarize_progress_snapshot(snapshot)
+
+  expect_equal(summary$total_finished, 210)
+  expect_equal(summary$total_draws, 400)
+  expect_equal(summary$phase, "mixed")
+  expect_equal(summary$total_divergences, 2L)
+  expect_equal(summary$slowest_chain, 2L)
+  expect_equal(summary$min_step_size, 0.015)
+  expect_equal(summary$max_latest_num_steps, 63L)
+  expect_equal(summary$first_divergence, "chain 2 draw 17")
+  expect_match(summary$status, "div 2")
+  expect_match(summary$status, "c2")
+  expect_match(summary$status, "lf")
+})
+
+test_that("cli callback only advances by new draws", {
+  updates <- list()
+  fake_update <- function(set = NULL, status = NULL, extra = NULL, id = NULL, force = FALSE) {
+    updates[[length(updates) + 1L]] <<- list(set = set, status = status, extra = extra, force = force)
+  }
+  callback <- nutpieR:::make_cli_progress_callback(
+    num_chains = 2L, num_warmup = 10L, num_draws = 10L,
+    id = "fake", update = fake_update, done = function(...) TRUE
+  )
+
+  callback(list(
+    list(chain = 1L, finished_draws = 3L, total_draws = 20L, divergences = 0L, tuning = TRUE, started = TRUE, latest_num_steps = 2L, total_num_steps = 6L, step_size = 0.1, runtime = 0.1, divergent_draws = integer()),
+    list(chain = 2L, finished_draws = 2L, total_draws = 20L, divergences = 0L, tuning = TRUE, started = TRUE, latest_num_steps = 3L, total_num_steps = 6L, step_size = 0.1, runtime = 0.1, divergent_draws = integer())
+  ))
+  callback(list(
+    list(chain = 1L, finished_draws = 3L, total_draws = 20L, divergences = 0L, tuning = TRUE, started = TRUE, latest_num_steps = 2L, total_num_steps = 6L, step_size = 0.1, runtime = 0.1, divergent_draws = integer()),
+    list(chain = 2L, finished_draws = 2L, total_draws = 20L, divergences = 0L, tuning = TRUE, started = TRUE, latest_num_steps = 3L, total_num_steps = 6L, step_size = 0.1, runtime = 0.1, divergent_draws = integer())
+  ))
+
+  expect_length(updates, 1L)
+  expect_equal(updates[[1]]$set, 5)
+  expect_match(updates[[1]]$status, "warmup")
+})
+
+
+test_that("explicit cli progress samples successfully", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  skip_if_not_installed("cli")
+  capture.output(
+    capture_messages(
+      draws <- nutpie_sample(
+        test_models$bernoulli, data = bernoulli_data(),
+        num_draws = 30, num_warmup = 30, num_chains = 2,
+        seed = 1L, refresh = 1L, progress = "cli"
+      )
+    ),
+    type = "output"
+  )
+  expect_s3_class(draws, "draws_array")
+})
+
+test_that("progress = 'none' produces no console output", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  expect_silent(
+    draws <- nutpie_sample(
+      test_models$bernoulli, data = bernoulli_data(),
+      num_draws = 30, num_warmup = 30, num_chains = 1,
+      seed = 1L, refresh = 100L, progress = "none"
+    )
+  )
+  expect_s3_class(draws, "draws_array")
+})
+
+test_that("a failing progress callback is disabled instead of killing sampling", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  call_count <- 0L
+  testthat::local_mocked_bindings(
+    make_cli_progress_callback = function(...) {
+      function(snapshot) {
+        call_count <<- call_count + 1L
+        stop("kaboom")
+      }
+    },
+    .package = "nutpieR"
+  )
+  capture.output(
+    draws <- nutpie_sample(
+      test_models$bernoulli, data = bernoulli_data(),
+      num_draws = 30, num_warmup = 30, num_chains = 1,
+      seed = 1L, refresh = 1L, progress = "cli"
+    ),
+    type = "output"
+  )
+  expect_s3_class(draws, "draws_array")
+  expect_lte(call_count, 2L)
+})


### PR DESCRIPTION
## Summary

- Interrupting a running `nutpie_sample()` (Stop button in Positron/RStudio) previously caused R to longjmp asynchronously from inside `wait_timeout`, skipping Rust destructors and crashing the session.
- Removed the 600s fallback wait duration — now always polls every 200ms so the interrupt check fires promptly regardless of progress settings.
- On each `Timeout` wakeup, peek at `R_interrupts_pending` directly before any R callback. If set, clear it and return a normal `Err` so extendr raises a clean R error at the call site.

## How it works

`R_CheckUserInterrupt()` handles interrupts via longjmp, which skips Rust destructors and bypasses the assignment — leaving the user with a confusing "object not found" on the next line. Instead, we read `R_interrupts_pending` (same flag, no new deps), clear it ourselves, and `return Err("Sampling interrupted.")`. extendr converts that to a normal R `stop()`, so the script aborts at the `nutpie_sample()` line with just:

```
Error: Sampling interrupted.
```

The check is placed before any R callback call, so the interrupt flag can't be consumed by R's evaluator during callback execution (which was a prior failure mode that made interrupts silently no-op).