### PR TITLE
fix: verify BridgeStan download TLS against OS trust store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,13 @@ See `tests/README.md` for the full list of optional test env vars and the cross-
 
 ## BridgeStan Patch
 
-We carry a patched bridgestan 2.7.0 in `src/rust/patches/bridgestan-2.7.0/`, referenced via `[patch.crates-io]` in Cargo.toml. Two changes from upstream:
+We carry a patched bridgestan 2.7.0 in `src/rust/patches/bridgestan-2.7.0/`, referenced via `[patch.crates-io]` in Cargo.toml. Three changes from upstream:
 
 1. **Pre-generated bindings** (`src/pregenerated_bindings.rs`): bindgen output for 22 `bs_*` FFI symbols, generated once. The `build.rs` copies this file instead of running bindgen. Eliminates LLVM/libclang requirement on all platforms.
 
 2. **Root cause**: upstream bridgestan runs bindgen with `dynamic_link_require_all(true)` and no allowlist. On Windows, system headers inject CRT symbols that `from_library()` then tries to resolve from the Stan model DLL — causing `GetProcAddress` error 127. The allowlist filters (`bs_.*`) fix this. Worth upstreaming.
+
+3. **OS trust store for downloads** (`src/download.rs`): `download_bridgestan_src()` builds a ureq agent with `RootCerts::PlatformVerifier` (ureq `platform-verifier` feature) instead of the bundled webpki-roots, so TLS-intercepting corporate proxies with a system-installed CA work (issue #30). Also worth upstreaming.
 
 **Regenerating bindings**: If bridgestan updates its C API, temporarily restore `bindgen` in the patch's `Cargo.toml`, build, copy `$OUT_DIR/bindings.rs` → `src/pregenerated_bindings.rs`.
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.7.5
+Version: 1.7.6
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# nutpieR 1.7.6
+
+* Fix #30: the one-time BridgeStan source download now verifies TLS
+  against the OS trust store instead of a bundled CA list, so it works
+  behind TLS-intercepting corporate proxies with a system-installed CA.
+
 # nutpieR 1.7.5
 
 * `save_warmup = FALSE` no longer stores warmup draws in Arrow memory before dropping them.

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
  "log",
  "path-absolutize",
  "tar",
- "thiserror",
+ "thiserror 2.0.18",
  "ureq",
 ]
 
@@ -336,6 +336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +397,16 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -919,6 +945,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,7 +1251,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1216,7 +1286,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1230,6 +1300,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -1438,7 +1514,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1522,6 +1598,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1617,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1552,6 +1667,47 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1667,11 +1823,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1724,6 +1900,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "ureq-proto",
  "utf-8",
  "webpki-roots",
@@ -1752,6 +1929,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1857,12 +2044,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1926,11 +2131,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1944,19 +2158,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1966,9 +2201,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1984,9 +2231,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1996,9 +2255,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -26,6 +26,9 @@ serde_json = '1'
 # On Windows, bindgen picks up CRT symbols from stddef.h/stdbool.h
 # (e.g. _errno, __security_init_cookie) which are not exported by
 # the Stan model DLL, causing GetProcAddress failures at load time.
+# Also patched: download_bridgestan_src() verifies TLS against the OS
+# trust store (ureq platform-verifier) instead of bundled webpki-roots,
+# so corporate-proxy CAs work (issue #30).
 bridgestan = { path = "patches/bridgestan-2.7.0" }
 
 [profile.release]

--- a/src/rust/patches/bridgestan-2.7.0/Cargo.toml
+++ b/src/rust/patches/bridgestan-2.7.0/Cargo.toml
@@ -83,6 +83,7 @@ version = "2.0.3"
 
 [dependencies.ureq]
 version = "3.0"
+features = ["platform-verifier"]
 optional = true
 
 [dev-dependencies.approx]

--- a/src/rust/patches/bridgestan-2.7.0/Cargo.toml.orig
+++ b/src/rust/patches/bridgestan-2.7.0/Cargo.toml.orig
@@ -13,7 +13,7 @@ libloading = "0.8.0"
 thiserror = "2.0.3"
 path-absolutize = { version = "3.1" }
 log = { version = "0.4" }
-ureq = { version = "3.0", optional = true }
+ureq = { version = "3.0", features = ["platform-verifier"], optional = true }
 tar = { version = "0.4", optional = true }
 flate2 = { version = "1.0", optional = true }
 dirs = { version = "6.0", optional = true }

--- a/src/rust/patches/bridgestan-2.7.0/src/download.rs
+++ b/src/rust/patches/bridgestan-2.7.0/src/download.rs
@@ -5,6 +5,7 @@ use log::info;
 use std::io::Read;
 use std::{env::temp_dir, fs, path::PathBuf};
 use tar::Archive;
+use ureq::tls::{RootCerts, TlsConfig};
 
 /// Download and unzip the BridgeStan source distribution for this version
 /// to `~/.bridgestan/bridgestan-$VERSION`.
@@ -29,7 +30,20 @@ pub fn download_bridgestan_src() -> Result<PathBuf> {
         let url = "https://github.com/roualdes/bridgestan/releases/download/".to_owned()
             + format!("v{VERSION}/bridgestan-{VERSION}.tar.gz").as_str();
 
-        let response = ureq::get(url.as_str())
+        // Verify TLS against the OS trust store rather than ureq's bundled
+        // webpki-roots, so corporate-proxy CAs installed on the system are
+        // honored (https://github.com/andytimm/nutpieR/issues/30).
+        let agent = ureq::Agent::new_with_config(
+            ureq::Agent::config_builder()
+                .tls_config(
+                    TlsConfig::builder()
+                        .root_certs(RootCerts::PlatformVerifier)
+                        .build(),
+                )
+                .build(),
+        );
+        let response = agent
+            .get(url.as_str())
             .call()
             .map_err(|e| BridgeStanError::DownloadFailed(e.to_string()))?;
         let len = response


### PR DESCRIPTION
Fixes #30.

## Problem

The one-time BridgeStan source download in the vendored bridgestan patch (`download_bridgestan_src()`) used a default `ureq` agent. ureq 3's default TLS stack is rustls with the bundled `webpki-roots` store (a static snapshot of Mozilla's CA list), which never consults the OS trust store. Corporate proxies that intercept TLS re-sign traffic with a company CA installed on the system — so the chain fails with `invalid peer certificate: UnknownIssuer`.

## Fix

Build the ureq agent with `RootCerts::PlatformVerifier` (ureq's `platform-verifier` feature, backed by `rustls-platform-verifier`):

- Windows / macOS: the OS certificate verifier, picking up system-installed corporate CAs
- Linux: the system cert bundle (including `SSL_CERT_FILE`)

This stays pure-rustls, so no OpenSSL build dependency is added on Linux (unlike a `native-tls` switch). Proxy resolution itself was already fine — ureq reads `HTTPS_PROXY`/`HTTP_PROXY` by default; only trust roots needed fixing.

## Verification

- `cargo check` passes with the updated patch
- The exact agent construction from the patch fetches `https://github.com/roualdes/bridgestan/releases/download/v2.7.0/bridgestan-2.7.0.tar.gz` with `200 OK` via the platform verifier (standalone test crate)

Can't reproduce the corporate-proxy MITM environment locally, so confirmation from the reporter on #30 would be ideal.

## Also in this PR

- Version bump to 1.7.6 + NEWS.md entry (for r-universe rebuild)
- CLAUDE.md / Cargo.toml patch-notes updated to document the third divergence from upstream bridgestan (worth upstreaming alongside the bindgen allowlist change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)