### PR TITLE
Failure-flag diagnostics (1.8.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.8.0
+Version: 1.8.1
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# nutpieR 1.8.1
+
+* The post-run summary flags low E-BFMI (any chain below `0.3`) with one warning
+  line; silent when every chain is healthy.
+* `nutpie_diagnostics()` now reports max R-hat, min ESS, and min E-BFMI, and
+  flags non-convergence (R-hat > `1.01`, ESS < `400`, E-BFMI < `0.3`), naming
+  the offending parameter and pointing to `posterior::summarize_draws()` for the
+  full table. Its print method drops the developer field dump.
+
 # nutpieR 1.8.0
 
 * Progress reporting overhaul. `progress = "auto"` now shows a compact,

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -27,6 +27,93 @@ rename_sampler_config <- function(json_str) {
   }, error = function(e) json_str)
 }
 
+# Failure-flag thresholds. One-directional: a trip proves a problem; staying
+# under proves nothing (so we flag, never certify). R-hat from Vehtari et al.
+# 2021 / posterior; ESS floor from the same; E-BFMI default matches CmdStanR's
+# `check_ebfmi`. EBFMI_THRESHOLD lives in progress.R (shared via the namespace).
+RHAT_THRESHOLD <- 1.01
+ESS_THRESHOLD  <- 400
+
+#' Per-chain E-BFMI using the grounded CmdStanR formula (NOT a fraction-of-draws
+#' heuristic). For each chain, with energy vector `e`:
+#' `(sum(diff(e)^2) / length(e)) / var(e)`. Returns a numeric vector named by
+#' chain id, `NA` per chain when energy is absent / has NAs / has < 3 draws /
+#' has zero variance. Returns `NULL` when there is no energy or chain field at
+#' all. Mirrors `cmdstanr::ebfmi` guards.
+#' @noRd
+ebfmi_per_chain <- function(diagnostics) {
+  if (is.null(diagnostics) || is.null(diagnostics$energy) ||
+      is.null(diagnostics$chain)) {
+    return(NULL)
+  }
+  energy <- as.numeric(diagnostics$energy)
+  chain <- as.integer(diagnostics$chain)
+  chains <- sort(unique(chain))
+  out <- vapply(chains, function(ch) {
+    e <- energy[chain == ch]
+    if (length(e) < 3L || anyNA(e)) return(NA_real_)
+    v <- stats::var(e)
+    if (!is.finite(v) || v <= 0) return(NA_real_)
+    (sum(diff(e)^2) / length(e)) / v
+  }, numeric(1))
+  stats::setNames(out, as.character(chains))
+}
+
+#' Cross-chain convergence extrema for the diagnostics print. Runs
+#' `posterior::summarise_draws()` with R-hat / bulk-ESS / tail-ESS and returns
+#' the worst value of each plus the offending variable name. R-hat needs >= 2
+#' chains, so `max_rhat`/`max_rhat_var` are `NULL` for single-chain runs.
+#' Computed lazily (print-only) so attaching the draws array as an attribute
+#' stays cheap. Returns `NULL` if `draws` is `NULL`.
+#' @noRd
+worst_rhat_ess <- function(draws) {
+  if (is.null(draws)) return(NULL)
+  num_chains <- tryCatch(posterior::nchains(draws),
+                         error = function(e) NA_integer_)
+  measures <- list(ess_bulk = posterior::ess_bulk,
+                   ess_tail = posterior::ess_tail)
+  if (isTRUE(num_chains >= 2L)) {
+    measures <- c(list(rhat = posterior::rhat), measures)
+  }
+  s <- do.call(posterior::summarise_draws, c(list(draws), measures))
+  pick <- function(col, fn) {
+    vals <- s[[col]]
+    if (is.null(vals) || all(is.na(vals))) return(list(val = NULL, var = NULL))
+    i <- fn(vals)
+    list(val = vals[[i]], var = as.character(s$variable[[i]]))
+  }
+  rhat <- if ("rhat" %in% names(s)) pick("rhat", which.max) else list(val = NULL, var = NULL)
+  bulk <- pick("ess_bulk", which.min)
+  tail <- pick("ess_tail", which.min)
+  list(
+    max_rhat = rhat$val, max_rhat_var = rhat$var,
+    min_ess_bulk = bulk$val, min_ess_bulk_var = bulk$var,
+    min_ess_tail = tail$val, min_ess_tail_var = tail$var
+  )
+}
+
+#' Shared divergence-severity wording so the post-run summary and the
+#' diagnostics print speak with one voice. `severe` (any per-chain or pooled
+#' divergence share >= `DIV_SEVERE_THRESHOLD`) escalates from a tuning hint to
+#' a geometry warning. Returns a plain string (no glue braces) — each surface
+#' emits it with its own mechanism.
+#' @noRd
+format_div_severity_msg <- function(total_divs, div_frac, severe) {
+  plural <- if (identical(as.integer(total_divs), 1L)) "" else "s"
+  div_pct <- if (is.finite(div_frac)) sprintf("%.1f%%", 100 * div_frac) else "NA"
+  head <- sprintf("%d divergent transition%s (%s of post-warmup draws)",
+                  as.integer(total_divs), plural, div_pct)
+  if (isTRUE(severe)) {
+    paste0(head, "; results are not reliable. This usually means the model ",
+           "geometry is exposing a deeper problem, not just a tuning issue. ",
+           "Check parameterization, constraints, and priors before relying on ",
+           "the fit.")
+  } else {
+    paste0(head, ". Try increasing `target_accept`, inspecting pairs plots, ",
+           "or reparameterizing.")
+  }
+}
+
 #' Extract sampler diagnostics from nutpie draws
 #'
 #' Diagnostics are extracted directly from the nuts-rs sample-stats schema, so
@@ -84,7 +171,11 @@ nutpie_diagnostics <- function(draws) {
          call. = FALSE)
   }
   num_chains <- attr(draws, "num_chains") %||% dim(draws)[[2]] %||% 1L
-  structure(diag, class = "nutpie_diagnostics", num_chains = num_chains)
+  out <- structure(diag, class = "nutpie_diagnostics", num_chains = num_chains)
+  # Reference (not a copy) so print() can compute R-hat/ESS lazily; nothing is
+  # computed here, so field access stays cheap.
+  attr(out, "draws") <- draws
+  out
 }
 
 #' @export
@@ -120,15 +211,113 @@ print.nutpie_diagnostics <- function(x, ...) {
                 paste(sprintf("%.4f", step_sizes), collapse = ", ")))
   }
 
-  if (!is.null(x$diverging) && sum(x$diverging, na.rm = TRUE) > 0) {
-    cat("\n")
-    cat("  Warning: divergent transitions detected. Consider increasing\n")
-    cat("  target_accept or reparameterizing the model.\n")
+  # ── Cross-chain failure flags (the post-completion diagnostics) ───────────
+  # Numbers shown every time (like Mean accept / Step size); a warning line
+  # fires only on a threshold trip, naming the offending parameter. All three
+  # checks degrade quietly when their preconditions are unmet.
+  rhat_ess <- worst_rhat_ess(attr(x, "draws"))
+  if (!is.null(rhat_ess)) {
+    if (!is.null(rhat_ess$max_rhat)) {
+      cat(sprintf("  Max R-hat:     %.2f (%s)\n",
+                  rhat_ess$max_rhat, rhat_ess$max_rhat_var))
+    } else {
+      cat("  Max R-hat:     - (needs >= 2 chains)\n")
+    }
+    if (!is.null(rhat_ess$min_ess_bulk)) {
+      cat(sprintf("  Min Bulk-ESS:  %.0f (%s)\n",
+                  rhat_ess$min_ess_bulk, rhat_ess$min_ess_bulk_var))
+    }
+    if (!is.null(rhat_ess$min_ess_tail)) {
+      cat(sprintf("  Min Tail-ESS:  %.0f (%s)\n",
+                  rhat_ess$min_ess_tail, rhat_ess$min_ess_tail_var))
+    }
   }
 
-  cat(sprintf("\nAvailable fields: %s\n",
-              paste(names(x), collapse = ", ")))
-  cat("Use `str(nutpie_diagnostics(draws))` for raw diagnostic vectors.\n")
+  ebfmi <- ebfmi_per_chain(x)
+  finite_ebfmi <- if (!is.null(ebfmi)) ebfmi[is.finite(ebfmi)] else numeric()
+  if (length(finite_ebfmi) > 0L) {
+    cat(sprintf("  Min E-BFMI:    %.2f\n", min(finite_ebfmi)))
+  }
+
+  # Divergence flag: same severity-gated vocabulary as the post-run summary.
+  if (!is.null(x$diverging)) {
+    n_div <- sum(x$diverging, na.rm = TRUE)
+    if (n_div > 0L) {
+      div_frac <- n_div / n
+      per_chain_frac <- NA_real_
+      if (!is.null(x$chain)) {
+        ch <- as.integer(x$chain)
+        dv <- as.logical(x$diverging)
+        per_chain_frac <- vapply(sort(unique(ch)), function(c) {
+          mean(dv[ch == c], na.rm = TRUE)
+        }, numeric(1))
+      }
+      severe <- is.finite(div_frac) &&
+        (div_frac >= DIV_SEVERE_THRESHOLD ||
+           any(per_chain_frac >= DIV_SEVERE_THRESHOLD, na.rm = TRUE))
+      cli::cli_alert_warning("{format_div_severity_msg(n_div, div_frac, severe)}")
+    }
+  }
+
+  # Convergence flag (R-hat / ESS): combine into one line, naming offenders.
+  if (!is.null(rhat_ess)) {
+    rhat_trip <- !is.null(rhat_ess$max_rhat) && is.finite(rhat_ess$max_rhat) &&
+      rhat_ess$max_rhat > RHAT_THRESHOLD
+    bulk_trip <- !is.null(rhat_ess$min_ess_bulk) &&
+      is.finite(rhat_ess$min_ess_bulk) && rhat_ess$min_ess_bulk < ESS_THRESHOLD
+    tail_trip <- !is.null(rhat_ess$min_ess_tail) &&
+      is.finite(rhat_ess$min_ess_tail) && rhat_ess$min_ess_tail < ESS_THRESHOLD
+    if (rhat_trip || bulk_trip || tail_trip) {
+      parts <- character()
+      vars <- character()
+      if (rhat_trip) {
+        parts <- c(parts, sprintf("R-hat %.2f > %s",
+                                  rhat_ess$max_rhat, format(RHAT_THRESHOLD)))
+        vars <- c(vars, rhat_ess$max_rhat_var)
+      }
+      # When bulk and tail trip on the same parameter, fold them into one
+      # clause ("Bulk/Tail-ESS 6/168 < 400") rather than two "and"s.
+      if (bulk_trip && tail_trip &&
+          identical(rhat_ess$min_ess_bulk_var, rhat_ess$min_ess_tail_var)) {
+        parts <- c(parts, sprintf("Bulk/Tail-ESS %.0f/%.0f < %d",
+                                  rhat_ess$min_ess_bulk, rhat_ess$min_ess_tail,
+                                  ESS_THRESHOLD))
+        vars <- c(vars, rhat_ess$min_ess_bulk_var)
+      } else {
+        if (bulk_trip) {
+          parts <- c(parts, sprintf("Bulk-ESS %.0f < %d",
+                                    rhat_ess$min_ess_bulk, ESS_THRESHOLD))
+          vars <- c(vars, rhat_ess$min_ess_bulk_var)
+        }
+        if (tail_trip) {
+          parts <- c(parts, sprintf("Tail-ESS %.0f < %d",
+                                    rhat_ess$min_ess_tail, ESS_THRESHOLD))
+          vars <- c(vars, rhat_ess$min_ess_tail_var)
+        }
+      }
+      uvars <- unique(vars)
+      var_label <- paste(sprintf("`%s`", uvars), collapse = ", ")
+      # No summarize_draws pointer here — the always-shown footer carries it
+      # once, so a flagged fit doesn't repeat it.
+      msg <- sprintf("%s for %s: chains may not have mixed.",
+                     paste(parts, collapse = " and "), var_label)
+      cli::cli_alert_warning("{msg}")
+    }
+  }
+
+  # E-BFMI flag: independent of geometry; energy problems coexist with clean
+  # divergence/treedepth.
+  if (!is.null(ebfmi)) {
+    n_low <- sum(is.finite(ebfmi) & ebfmi < EBFMI_THRESHOLD)
+    if (n_low > 0L) {
+      n_chains_e <- length(ebfmi)
+      cli::cli_alert_warning(
+        "{n_low} of {n_chains_e} chains had an E-BFMI below 0.3 — the posterior may have heavy tails the sampler explores inefficiently. Consider reparameterizing."
+      )
+    }
+  }
+
+  cat("\nFor the full per-parameter table, see posterior::summarize_draws(draws).\n")
   invisible(x)
 }
 

--- a/R/progress.R
+++ b/R/progress.R
@@ -6,6 +6,7 @@ SPREAD_TRIGGER_POINTS <- 15    # percentage-point chain spread to trigger the hi
 SPREAD_MEDIAN_FLOOR   <- 0.10  # median chain must be past this fraction first
 CAP_SUMMARY_THRESHOLD <- 0.05  # %-at-cap gate for the end-of-run advice line
 DIV_SEVERE_THRESHOLD  <- 0.10  # divergence share that means the fit is unreliable
+EBFMI_THRESHOLD       <- 0.3   # per-chain E-BFMI floor (CmdStanR check_ebfmi default)
 
 #' cli routing depends only on the environment: an interactive session that
 #' isn't rendering a knitr document. cli itself is a hard dependency, so there
@@ -609,6 +610,21 @@ print_sampling_diagnostic_summary <- function(diagnostics, num_chains, elapsed,
         "stay long."
       )
     )
+  }
+
+  # E-BFMI flag — independent of the divergence/cap branches above. Energy-
+  # direction inefficiency coexists with clean within-trajectory geometry, so
+  # this is its own block, not an `else if`. Flag-only (silent when every chain
+  # is healthy), framed as "N of M chains" to match CmdStanR.
+  ebfmi <- ebfmi_per_chain(diagnostics)
+  if (!is.null(ebfmi)) {
+    n_low <- sum(is.finite(ebfmi) & ebfmi < EBFMI_THRESHOLD)
+    if (n_low > 0L) {
+      n_chains_e <- length(ebfmi)
+      cli::cli_alert_warning(
+        "{n_low} of {n_chains_e} chains had an E-BFMI below 0.3 — the posterior may have heavy tails the sampler explores inefficiently. Consider reparameterizing."
+      )
+    }
   }
   invisible(NULL)
 }

--- a/tests/testthat/test-diagnostics-print.R
+++ b/tests/testthat/test-diagnostics-print.R
@@ -1,0 +1,127 @@
+# Failure-flag behaviour of print.nutpie_diagnostics(). All cases are synthetic
+# (no compiled model needed): we build a posterior::draws_array, attach the same
+# attributes nutpie_sample() does (sample.R:306-311), and assert on the printed
+# output. cat() lines go to stdout (expect_output); cli_alert_* flag lines go to
+# the message stream (capture_messages).
+
+# Build a draws_array with mu chain-means `mu_means` (one per chain) plus a
+# well-mixed sigma, and attach a diagnostics attribute of the shape
+# nutpie_diagnostics() expects.
+make_diag_object <- function(mu_means, energy_pattern = "healthy",
+                             diverging = NULL, n_iter = 200L) {
+  set.seed(42)
+  n_chain <- length(mu_means)
+  arr <- array(0, dim = c(n_iter, n_chain, 2L),
+               dimnames = list(NULL, NULL, c("mu", "sigma")))
+  for (ch in seq_len(n_chain)) {
+    arr[, ch, "mu"] <- stats::rnorm(n_iter, mu_means[ch], 0.1)
+    arr[, ch, "sigma"] <- stats::rnorm(n_iter, 1, 0.1)
+  }
+  draws <- posterior::as_draws_array(arr)
+
+  n <- n_iter * n_chain
+  energy <- if (identical(energy_pattern, "healthy")) {
+    rep(c(0, 10), length.out = n)            # high E-BFMI everywhere
+  } else {
+    rep(seq_len(n_iter), times = n_chain)    # slow drift -> low E-BFMI
+  }
+  if (is.null(diverging)) diverging <- rep(FALSE, n)
+
+  attr(draws, "diagnostics") <- list(
+    chain            = rep(seq_len(n_chain), each = n_iter),
+    draw             = rep(seq_len(n_iter), times = n_chain),
+    diverging        = diverging,
+    depth            = rep(2L, n),
+    step_size_bar    = rep(0.5, n),
+    mean_tree_accept = rep(0.9, n),
+    energy           = energy
+  )
+  attr(draws, "num_chains") <- n_chain
+  nutpie_diagnostics(draws)
+}
+
+test_that("print always shows Max R-hat / ESS / E-BFMI info lines", {
+  diag <- make_diag_object(c(0, 0, 0, 0))
+  out <- paste(capture.output(suppressMessages(print(diag))), collapse = "\n")
+  expect_match(out, "Max R-hat")
+  expect_match(out, "Min Bulk-ESS")
+  expect_match(out, "Min Tail-ESS")
+  expect_match(out, "Min E-BFMI")
+  expect_match(out, "posterior::summarize_draws(draws)", fixed = TRUE)
+  # Developer field dump is gone.
+  expect_false(grepl("Available fields", out, fixed = TRUE))
+})
+
+test_that("a non-mixing (bimodal) fit flags R-hat/ESS and names the parameter", {
+  # Chains split across mu = -2 / +2: clean geometry, but R-hat blows out and
+  # ESS collapses for mu. Short chains (n_iter = 60) drop both bulk and tail ESS
+  # below 400 so the folded "Bulk/Tail-ESS" clause is exercised.
+  diag <- make_diag_object(c(-2, -2, 2, 2), n_iter = 60L)
+  msgs <- paste(testthat::capture_messages(
+    suppressWarnings(print(diag))
+  ), collapse = "")
+  expect_match(msgs, "chains may not have mixed", fixed = TRUE)
+  expect_match(msgs, "`mu`", fixed = TRUE)
+  # Bulk + tail trip on the same parameter -> one folded clause, not two.
+  expect_match(msgs, "Bulk/Tail-ESS", fixed = TRUE)
+  # The summarize_draws pointer is NOT repeated in the flag; it lives once in
+  # the footer (stdout), not the message stream.
+  expect_false(grepl("summarize_draws", msgs, fixed = TRUE))
+})
+
+test_that("a clean fit emits no failure flags", {
+  diag <- make_diag_object(c(0, 0, 0, 0))
+  msgs <- paste(testthat::capture_messages(print(diag)), collapse = "")
+  expect_false(grepl("may not have mixed", msgs, fixed = TRUE))
+  expect_false(grepl("E-BFMI below", msgs, fixed = TRUE))
+  expect_false(grepl("divergent transition", msgs, fixed = TRUE))
+})
+
+test_that("low-E-BFMI fit flags energy independently of clean geometry", {
+  diag <- make_diag_object(c(0, 0, 0, 0), energy_pattern = "drift")
+  msgs <- paste(testthat::capture_messages(print(diag)), collapse = "")
+  expect_match(msgs, "chains had an E-BFMI below 0.3", fixed = TRUE)
+})
+
+test_that("single-chain print skips R-hat with a note but still shows ESS", {
+  diag <- make_diag_object(c(0))
+  out <- paste(capture.output(suppressMessages(print(diag))), collapse = "\n")
+  expect_match(out, "needs >= 2 chains", fixed = TRUE)
+  expect_match(out, "Min Bulk-ESS")
+})
+
+test_that("divergence flag uses the severity-gated vocabulary", {
+  # 15% of draws diverge -> severe escalation wording.
+  n_iter <- 200L
+  n_chain <- 2L
+  n <- n_iter * n_chain
+  diverging <- rep(FALSE, n)
+  diverging[seq_len(round(0.15 * n))] <- TRUE
+  diag <- make_diag_object(c(0, 0), diverging = diverging)
+  msgs <- paste(testthat::capture_messages(print(diag)), collapse = "")
+  expect_match(msgs, "results are not reliable", fixed = TRUE)
+  expect_match(msgs, "deeper problem, not just a tuning issue", fixed = TRUE)
+})
+
+test_that("worst_rhat_ess returns extrema and offending variables", {
+  arr <- array(0, dim = c(200L, 4L, 2L),
+               dimnames = list(NULL, NULL, c("mu", "sigma")))
+  set.seed(1)
+  means <- c(-2, -2, 2, 2)
+  for (ch in seq_len(4L)) {
+    arr[, ch, "mu"] <- stats::rnorm(200, means[ch], 0.1)
+    arr[, ch, "sigma"] <- stats::rnorm(200, 1, 0.1)
+  }
+  draws <- posterior::as_draws_array(arr)
+  res <- nutpieR:::worst_rhat_ess(draws)
+  expect_true(res$max_rhat > 1.01)
+  expect_identical(res$max_rhat_var, "mu")
+  expect_true(res$min_ess_bulk < 400)
+  expect_identical(res$min_ess_bulk_var, "mu")
+
+  # Single chain: R-hat unavailable, ESS still computed.
+  single <- posterior::as_draws_array(arr[, 1, , drop = FALSE])
+  res1 <- nutpieR:::worst_rhat_ess(single)
+  expect_null(res1$max_rhat)
+  expect_false(is.null(res1$min_ess_bulk))
+})

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -803,3 +803,66 @@ test_that("a failing progress callback is disabled instead of killing sampling",
   expect_equal(call_count, 1L)
   expect_false(grepl("Error in", paste(out, collapse = "\n"), fixed = TRUE))
 })
+
+test_that("ebfmi_per_chain matches the hand-computed CmdStanR formula", {
+  # e = c(1, 3, 2, 5): mean squared successive diff = (4+1+9)/4 = 3.5;
+  # var = 8.75/3 = 2.91667; E-BFMI = 3.5 / 2.91667 = 1.2.
+  diags <- list(energy = c(1, 3, 2, 5), chain = rep(1L, 4))
+  out <- nutpieR:::ebfmi_per_chain(diags)
+  expect_equal(unname(out[["1"]]), 1.2)
+
+  # Guards: < 3 draws, NA energy, and absent energy all degrade to NA / NULL.
+  expect_true(is.na(nutpieR:::ebfmi_per_chain(
+    list(energy = c(1, 2), chain = c(1L, 1L))
+  )[["1"]]))
+  expect_true(is.na(nutpieR:::ebfmi_per_chain(
+    list(energy = c(1, NA, 3, 4), chain = rep(1L, 4))
+  )[["1"]]))
+  expect_null(nutpieR:::ebfmi_per_chain(list(chain = rep(1L, 4))))
+})
+
+test_that("end summary flags a low-E-BFMI chain without touching clean geometry", {
+  # Chain 1: energy is a slow drift (1:20) -> tiny successive diffs vs a large
+  # variance -> E-BFMI well below 0.3. Chain 2: energy alternates 0/10 -> large
+  # successive diffs vs modest variance -> E-BFMI ~4 (healthy). Geometry is
+  # clean throughout (no divergences, low treedepth) so only the E-BFMI block
+  # should fire.
+  diags <- list(
+    chain     = rep(1:2, each = 20),
+    n_steps   = rep(3, 40),
+    depth     = rep(2L, 40),
+    step_size = rep(0.5, 40),
+    diverging = rep(FALSE, 40),
+    energy    = c(seq_len(20), rep(c(0, 10), 10))
+  )
+  ebfmi <- nutpieR:::ebfmi_per_chain(diags)
+  expect_true(ebfmi[["1"]] < 0.3)
+  expect_true(ebfmi[["2"]] >= 0.3)
+
+  msgs <- testthat::capture_messages(
+    nutpieR:::print_sampling_diagnostic_summary(
+      diags, num_chains = 2L, elapsed = 1, max_treedepth = 10L
+    )
+  )
+  joined <- paste(msgs, collapse = "")
+  expect_match(joined, "1 of 2 chains had an E-BFMI below 0.3", fixed = TRUE)
+  # Clean geometry: the honest completion line still fires, no false flags.
+  expect_match(joined, "no divergences", fixed = TRUE)
+})
+
+test_that("end summary stays silent on E-BFMI when every chain is healthy", {
+  diags <- list(
+    chain     = rep(1:2, each = 20),
+    n_steps   = rep(3, 40),
+    depth     = rep(2L, 40),
+    step_size = rep(0.5, 40),
+    diverging = rep(FALSE, 40),
+    energy    = rep(c(0, 10), 20)   # both chains alternate -> high E-BFMI
+  )
+  msgs <- testthat::capture_messages(
+    nutpieR:::print_sampling_diagnostic_summary(
+      diags, num_chains = 2L, elapsed = 1, max_treedepth = 10L
+    )
+  )
+  expect_false(grepl("E-BFMI", paste(msgs, collapse = "")))
+})


### PR DESCRIPTION
1.8.0 shipped a nice post-run summary, but everything in it was within-trajectory geometry: divergences, treedepth, grad/draw. So: the same signals the live progress bar already showeed.

The cross-chain diagnostics only become available once sampling finishes, and we weren't reporting them by default. Examples: weakly identified or multimodal posterior with clean geometry and zero divergences (R-hat 1.7, ESS on the floor) passed.

This PR adds a couple quick failure flags to cover that:

- E-BFMI in the post-run summary. Energy is already in our schema, so per-chain E-BFMI is nearly free, and it catches inefficient energy-direction exploration that divergences can't see. 
- R-hat, ESS, and E-BFMI in `nutpie_diagnostics()`. The print method now always shows max R-hat, min bulk/tail ESS, and min E-BFMI, the same way it already shows mean accept and step size, and adds a warning line naming the offending parameter when something trips.

Thresholds are the usual ones: E-BFMI < 0.3 (CmdStanR's `check_ebfmi`), R-hat > 1.01 and ESS < 400 (Vehtari et al. 2021).

# Testing

Unit tests for the new helpers, plus print coverage for a bimodal non-mixing fit, a clean fit, a low-E-BFMI fit, and the single-chain case. I also eyeballed it through `scratch/progress_summary_dogfood.R`, which prints `nutpie_diagnostics()` on the bimodal fit
