### PR TITLE
Efficiency, validation, and IDE progress fixes (1.8.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.8.1
+Version: 1.8.2
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,15 @@
 # nutpieR 1.8.2
 
+* Live sampling progress streams in the RStudio and Positron consoles again
+  (GitHub #34); a 1.8.0 regression suppressed it in both.
 * `nutpie_sample()` and `nutpie_compile_model()` now reject malformed arguments
   (non-`TRUE`/`FALSE` flags, out-of-range tuning values) with a clear error
   instead of silently coercing them.
 * The post-run treedepth-cap advice uses the sampler's effective `max_treedepth`
   rather than assuming `10`.
 * Fixed a debug-build abort when compiling with no extra `stanc`/`make` args.
+* Restored clean `R CMD check` on binary platforms (test error + non-ASCII
+  warning).
 
 # nutpieR 1.8.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# nutpieR 1.8.2
+
+* `nutpie_sample()` and `nutpie_compile_model()` now reject malformed arguments
+  (non-`TRUE`/`FALSE` flags, out-of-range tuning values) with a clear error
+  instead of silently coercing them.
+* The post-run treedepth-cap advice uses the sampler's effective `max_treedepth`
+  rather than assuming `10`.
+* Fixed a debug-build abort when compiling with no extra `stanc`/`make` args.
+
 # nutpieR 1.8.1
 
 * The post-run summary flags low E-BFMI (any chain below `0.3`) with one warning

--- a/R/compile.R
+++ b/R/compile.R
@@ -97,8 +97,9 @@ nutpie_compile_model <- function(stan_file = NULL, code = NULL,
     )
   }
 
-  verbose <- as.integer(verbose)
-  use_cache <- isTRUE(cache) &&
+  verbose <- check_count(verbose, "verbose", min = 0L)
+  cache <- check_flag(cache, "cache")
+  use_cache <- cache &&
     !identical(Sys.getenv("NUTPIER_DISABLE_COMPILE_CACHE"), "1")
 
   bundle <- if (!is.null(code)) {

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -137,7 +137,7 @@ ebfmi_warning_msg <- function(ebfmi) {
   n_low <- sum(is.finite(ebfmi) & ebfmi < EBFMI_THRESHOLD)
   if (n_low == 0L) return(NULL)
   sprintf(
-    paste0("%d of %d chains had an E-BFMI below 0.3 — the posterior may have ",
+    paste0("%d of %d chains had an E-BFMI below 0.3 \u2014 the posterior may have ",
            "heavy tails the sampler explores inefficiently. Consider ",
            "reparameterizing."),
     n_low, length(ebfmi)

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -114,6 +114,36 @@ format_div_severity_msg <- function(total_divs, div_frac, severe) {
   }
 }
 
+#' Shared "is this fit's divergence count severe?" test. `div_frac` is the
+#' pooled post-warmup divergence share; `per_chain_frac` a per-chain vector
+#' (NA-tolerant). Severe when either crosses `DIV_SEVERE_THRESHOLD` — the same
+#' rule the post-run summary and the diagnostics print both apply, so they
+#' can't disagree on whether to escalate from a tuning hint to a geometry
+#' warning.
+#' @noRd
+divergence_is_severe <- function(div_frac, per_chain_frac) {
+  is.finite(div_frac) &&
+    (div_frac >= DIV_SEVERE_THRESHOLD ||
+       any(per_chain_frac >= DIV_SEVERE_THRESHOLD, na.rm = TRUE))
+}
+
+#' Shared E-BFMI warning sentence. Returns the "N of M chains ..." string when
+#' any chain falls below `EBFMI_THRESHOLD`, else `NULL`, so the post-run summary
+#' and the diagnostics print never drift on the number (and threshold) users
+#' quote. The returned string carries no glue braces; each surface emits it.
+#' @noRd
+ebfmi_warning_msg <- function(ebfmi) {
+  if (is.null(ebfmi)) return(NULL)
+  n_low <- sum(is.finite(ebfmi) & ebfmi < EBFMI_THRESHOLD)
+  if (n_low == 0L) return(NULL)
+  sprintf(
+    paste0("%d of %d chains had an E-BFMI below 0.3 — the posterior may have ",
+           "heavy tails the sampler explores inefficiently. Consider ",
+           "reparameterizing."),
+    n_low, length(ebfmi)
+  )
+}
+
 #' Extract sampler diagnostics from nutpie draws
 #'
 #' Diagnostics are extracted directly from the nuts-rs sample-stats schema, so
@@ -252,9 +282,7 @@ print.nutpie_diagnostics <- function(x, ...) {
           mean(dv[ch == c], na.rm = TRUE)
         }, numeric(1))
       }
-      severe <- is.finite(div_frac) &&
-        (div_frac >= DIV_SEVERE_THRESHOLD ||
-           any(per_chain_frac >= DIV_SEVERE_THRESHOLD, na.rm = TRUE))
+      severe <- divergence_is_severe(div_frac, per_chain_frac)
       cli::cli_alert_warning("{format_div_severity_msg(n_div, div_frac, severe)}")
     }
   }
@@ -307,14 +335,9 @@ print.nutpie_diagnostics <- function(x, ...) {
 
   # E-BFMI flag: independent of geometry; energy problems coexist with clean
   # divergence/treedepth.
-  if (!is.null(ebfmi)) {
-    n_low <- sum(is.finite(ebfmi) & ebfmi < EBFMI_THRESHOLD)
-    if (n_low > 0L) {
-      n_chains_e <- length(ebfmi)
-      cli::cli_alert_warning(
-        "{n_low} of {n_chains_e} chains had an E-BFMI below 0.3 — the posterior may have heavy tails the sampler explores inefficiently. Consider reparameterizing."
-      )
-    }
+  ebfmi_msg <- ebfmi_warning_msg(ebfmi)
+  if (!is.null(ebfmi_msg)) {
+    cli::cli_alert_warning("{ebfmi_msg}")
   }
 
   cat("\nFor the full per-parameter table, see posterior::summarize_draws(draws).\n")

--- a/R/progress.R
+++ b/R/progress.R
@@ -12,8 +12,9 @@ EBFMI_THRESHOLD       <- 0.3   # per-chain E-BFMI floor (CmdStanR check_ebfmi de
 #' isn't rendering a knitr document. cli itself is a hard dependency, so there
 #' is no package-availability check to make.
 #' @noRd
-should_use_cli_progress <- function(interactive = base::interactive()) {
-  interactive && !isTRUE(getOption("knitr.in.progress"))
+should_use_cli_progress <- function(interactive = base::interactive(),
+                                    knitting = isTRUE(getOption("knitr.in.progress"))) {
+  interactive && !knitting
 }
 
 #' `use_cli` is injectable so the dispatch can be tested without mocking
@@ -418,6 +419,21 @@ progress_supports_color <- function() {
   cli::num_ansi_colors() > 1L
 }
 
+#' Is there a *global* message handler installed (`globalCallingHandlers()`)?
+#'
+#' Positron's R kernel (ark) registers a global `message` handler that redirects
+#' message output to the console and invokes the `muffleMessage` restart. That
+#' is a redirect, not suppression: it must not be mistaken for `suppressMessages()`
+#' (see [progress_messages_muffled()]). The query form of `globalCallingHandlers()`
+#' is safe to call with handlers on the stack; only the *setting* form errors.
+#' @noRd
+has_global_message_handler <- function() {
+  handlers <- tryCatch(globalCallingHandlers(), error = function(e) list())
+  # The classes a progress `message()` would match: derived from the same
+  # condition the probe signals so the two can't drift.
+  any(names(handlers) %in% class(simpleMessage("")))
+}
+
 #' Detect whether message conditions are currently being muffled.
 #'
 #' This must run before entering the Rust sampling call. R message handlers
@@ -425,16 +441,23 @@ progress_supports_color <- function() {
 #' progress callback, so the callback closures capture this value up front. The
 #' empty probe condition is observable to non-muffling message handlers, but it
 #' has no default output.
+#'
+#' The probe only exists to honour `suppressMessages()`. A *global* message
+#' handler (e.g. Positron's ark, which redirects output and calls
+#' `muffleMessage`) would otherwise trip the probe and silence all progress even
+#' though the user never asked for it (GitHub #34) -- so when one is present we
+#' report "not muffled" and let the callback emit. The trade-off is that
+#' `suppressMessages()` does not silence *live* progress under such a handler;
+#' the start banner and end summary, emitted at the R top level, are still
+#' suppressed normally.
 #' @noRd
 progress_messages_muffled <- function() {
+  if (has_global_message_handler()) return(FALSE)
   muffled <- FALSE
-  withRestarts({
-    signalCondition(simpleMessage(""))
-    FALSE
-  }, muffleMessage = function() {
-    muffled <<- TRUE
-    TRUE
-  })
+  withRestarts(
+    signalCondition(simpleMessage("")),
+    muffleMessage = function() muffled <<- TRUE
+  )
   muffled
 }
 

--- a/R/progress.R
+++ b/R/progress.R
@@ -276,28 +276,31 @@ format_min_step <- function(snapshot) {
   sprintf("%.3g", min(finite_steps))
 }
 
+STATUS_TOKEN_NAMES <- c("div", "grad", "draws", "spread", "spark", "lag", "step", "tdepth")
+
+#' @noRd
+format_status_token <- function(name, snapshot, summary, spread_active) {
+  switch(name,
+    div    = format_divergence_status(summary$total_divergences),
+    grad   = format_gradient_status(summary$avg_num_steps),
+    draws  = format_chain_draw_range(snapshot),
+    spread = format_chain_spread(snapshot, active = spread_active),
+    spark  = format_chain_spark(snapshot),
+    lag    = format_chain_lag(snapshot),
+    step   = format_min_step(snapshot),
+    tdepth = format_treedepth_status(summary$max_latest_num_steps)
+  )
+}
+
 #' @noRd
 format_status_tokens <- function(snapshot, summary, format_str,
                                  spread_active = FALSE) {
-  # Token -> producer table. Thunks (not values) so a token's formatter runs
-  # only when that `{token}` is present — `{spark}`/`{spread}` are opt-in and
-  # absent from the default format, so they must not be computed every refresh.
-  # Add a row to support a new token.
-  producers <- list(
-    div    = function() format_divergence_status(summary$total_divergences),
-    grad   = function() format_gradient_status(summary$avg_num_steps),
-    draws  = function() format_chain_draw_range(snapshot),
-    spread = function() format_chain_spread(snapshot, active = spread_active),
-    spark  = function() format_chain_spark(snapshot),
-    lag    = function() format_chain_lag(snapshot),
-    step   = function() format_min_step(snapshot),
-    tdepth = function() format_treedepth_status(summary$max_latest_num_steps)
-  )
   result <- format_str
-  for (name in names(producers)) {
+  for (name in STATUS_TOKEN_NAMES) {
     token <- paste0("{", name, "}")
     if (grepl(token, result, fixed = TRUE)) {
-      result <- gsub(token, producers[[name]](), result, fixed = TRUE)
+      result <- gsub(token, format_status_token(name, snapshot, summary, spread_active),
+                     result, fixed = TRUE)
     }
   }
   # Collapse empty segments left by tokens that returned "". Multi-pass: a run

--- a/R/progress.R
+++ b/R/progress.R
@@ -279,27 +279,27 @@ format_min_step <- function(snapshot) {
 #' @noRd
 format_status_tokens <- function(snapshot, summary, format_str,
                                  spread_active = FALSE) {
+  # Token -> producer table. Thunks (not values) so a token's formatter runs
+  # only when that `{token}` is present — `{spark}`/`{spread}` are opt-in and
+  # absent from the default format, so they must not be computed every refresh.
+  # Add a row to support a new token.
+  producers <- list(
+    div    = function() format_divergence_status(summary$total_divergences),
+    grad   = function() format_gradient_status(summary$avg_num_steps),
+    draws  = function() format_chain_draw_range(snapshot),
+    spread = function() format_chain_spread(snapshot, active = spread_active),
+    spark  = function() format_chain_spark(snapshot),
+    lag    = function() format_chain_lag(snapshot),
+    step   = function() format_min_step(snapshot),
+    tdepth = function() format_treedepth_status(summary$max_latest_num_steps)
+  )
   result <- format_str
-  if (grepl("{div}", format_str, fixed = TRUE))
-    result <- gsub("{div}", format_divergence_status(summary$total_divergences),
-                   result, fixed = TRUE)
-  if (grepl("{grad}", format_str, fixed = TRUE))
-    result <- gsub("{grad}", format_gradient_status(summary$avg_num_steps),
-                   result, fixed = TRUE)
-  if (grepl("{draws}", format_str, fixed = TRUE))
-    result <- gsub("{draws}", format_chain_draw_range(snapshot), result, fixed = TRUE)
-  if (grepl("{spread}", format_str, fixed = TRUE))
-    result <- gsub("{spread}", format_chain_spread(snapshot, active = spread_active),
-                   result, fixed = TRUE)
-  if (grepl("{spark}", format_str, fixed = TRUE))
-    result <- gsub("{spark}", format_chain_spark(snapshot), result, fixed = TRUE)
-  if (grepl("{lag}", format_str, fixed = TRUE))
-    result <- gsub("{lag}", format_chain_lag(snapshot), result, fixed = TRUE)
-  if (grepl("{step}", format_str, fixed = TRUE))
-    result <- gsub("{step}", format_min_step(snapshot), result, fixed = TRUE)
-  if (grepl("{tdepth}", format_str, fixed = TRUE))
-    result <- gsub("{tdepth}", format_treedepth_status(summary$max_latest_num_steps),
-                   result, fixed = TRUE)
+  for (name in names(producers)) {
+    token <- paste0("{", name, "}")
+    if (grepl(token, result, fixed = TRUE)) {
+      result <- gsub(token, producers[[name]](), result, fixed = TRUE)
+    }
+  }
   # Collapse empty segments left by tokens that returned "". Multi-pass: a run
   # of three or more empty tokens (e.g. "{div} | {spread} | {spark}") needs more
   # than one sweep because each gsub consumes a pipe non-overlapping.
@@ -551,9 +551,7 @@ print_sampling_diagnostic_summary <- function(diagnostics, num_chains, elapsed,
   total_draws <- sum(summary$draws, na.rm = TRUE)
   div_frac <- if (total_draws > 0L) total_divs / total_draws else NA_real_
   per_chain_div_frac <- ifelse(summary$draws > 0L, summary$divs / summary$draws, NA_real_)
-  severe_divergences <- is.finite(div_frac) &&
-    (div_frac >= DIV_SEVERE_THRESHOLD ||
-       any(per_chain_div_frac >= DIV_SEVERE_THRESHOLD, na.rm = TRUE))
+  severe_divergences <- divergence_is_severe(div_frac, per_chain_div_frac)
 
   cap_frac <- fraction_at_treedepth_cap(diagnostics, max_treedepth)
   cap_pct <- if (is.finite(cap_frac)) {
@@ -616,15 +614,9 @@ print_sampling_diagnostic_summary <- function(diagnostics, num_chains, elapsed,
   # direction inefficiency coexists with clean within-trajectory geometry, so
   # this is its own block, not an `else if`. Flag-only (silent when every chain
   # is healthy), framed as "N of M chains" to match CmdStanR.
-  ebfmi <- ebfmi_per_chain(diagnostics)
-  if (!is.null(ebfmi)) {
-    n_low <- sum(is.finite(ebfmi) & ebfmi < EBFMI_THRESHOLD)
-    if (n_low > 0L) {
-      n_chains_e <- length(ebfmi)
-      cli::cli_alert_warning(
-        "{n_low} of {n_chains_e} chains had an E-BFMI below 0.3 — the posterior may have heavy tails the sampler explores inefficiently. Consider reparameterizing."
-      )
-    }
+  ebfmi_msg <- ebfmi_warning_msg(ebfmi_per_chain(diagnostics))
+  if (!is.null(ebfmi_msg)) {
+    cli::cli_alert_warning("{ebfmi_msg}")
   }
   invisible(NULL)
 }

--- a/R/sample.R
+++ b/R/sample.R
@@ -198,7 +198,17 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   adaptation <- match.arg(adaptation)
   if (identical(adaptation, "low-rank")) adaptation <- "low_rank"
   progress <- match.arg(progress)
-  if (isTRUE(low_rank_modified_mass_matrix)) {
+  low_rank_modified_mass_matrix <- check_flag(
+    low_rank_modified_mass_matrix, "low_rank_modified_mass_matrix"
+  )
+  save_warmup <- check_flag(save_warmup, "save_warmup")
+  include <- check_flag(include, "include")
+  store_divergences <- check_flag(store_divergences, "store_divergences")
+  store_mass_matrix <- check_flag(store_mass_matrix, "store_mass_matrix")
+  store_unconstrained <- check_flag(store_unconstrained, "store_unconstrained")
+  store_gradient <- check_flag(store_gradient, "store_gradient")
+
+  if (low_rank_modified_mass_matrix) {
     warning(
       "`low_rank_modified_mass_matrix` is deprecated; use ",
       "`adaptation = \"low_rank\"` instead. ",
@@ -211,6 +221,15 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   num_warmup <- check_count(num_warmup, "num_warmup", min = 0L)
   num_chains <- check_count(num_chains, "num_chains", min = 1L)
   refresh <- check_count(refresh, "refresh", min = 0L)
+  max_treedepth <- check_optional_count(max_treedepth, "max_treedepth", min = 1L)
+  mindepth <- check_optional_count(mindepth, "mindepth", min = 0L)
+  extra_doublings <- check_optional_count(extra_doublings, "extra_doublings", min = 0L)
+  target_accept <- check_optional_probability(target_accept, "target_accept")
+  max_energy_error <- check_optional_positive(max_energy_error, "max_energy_error")
+  mass_matrix_gamma <- check_optional_positive(mass_matrix_gamma, "mass_matrix_gamma")
+  mass_matrix_eigval_cutoff <- check_optional_positive(
+    mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"
+  )
 
   if (is.null(cores)) {
     cores <- min(num_chains, parallel::detectCores())
@@ -229,11 +248,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
 
   resolved_progress <- resolve_progress_mode(progress, refresh)
   chain_format <- validate_chain_format(chain_format, resolved_progress)
-  progress_max_treedepth <- if (is.null(max_treedepth)) {
-    10L
-  } else {
-    check_count(max_treedepth, "max_treedepth", min = 1L)
-  }
+  # Will be replaced with the effective maxdepth from sampler_config after sampling.
 
   call_sample_stan <- function(progress_callback) {
     progress_callback <- protect_progress_callback(progress_callback)
@@ -244,13 +259,13 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
       num_chains,
       as.integer(seed),
       init_resolved$positions,
-      isTRUE(init_resolved$jitter),
-      isTRUE(save_warmup),
+      init_resolved$jitter,
+      save_warmup,
       cores,
-      isTRUE(store_divergences),
-      isTRUE(store_mass_matrix),
-      isTRUE(store_unconstrained),
-      isTRUE(store_gradient),
+      store_divergences,
+      store_mass_matrix,
+      store_unconstrained,
+      store_gradient,
       adaptation,
       opt_double(max_treedepth, "max_treedepth"),
       opt_double(mindepth, "mindepth"),
@@ -260,8 +275,8 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
       opt_double(mass_matrix_gamma, "mass_matrix_gamma"),
       opt_double(mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"),
       keep_indices,
-      isTRUE(flags$include_tp),
-      isTRUE(flags$include_gq),
+      flags$include_tp,
+      flags$include_gq,
       progress_callback
     )
   }
@@ -310,6 +325,19 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   attr(draws, "num_draws") <- num_draws
   attr(draws, "sampler_config") <- rename_sampler_config(raw$sampler_config)
 
+  # Use the sampler's effective maxdepth for %-at-cap advice, falling back to
+  # nuts-rs's documented default only when the config is unreadable.
+  progress_max_treedepth <- 10L
+  tryCatch(
+    {
+      cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"), simplifyVector = TRUE)
+      if (!is.null(cfg$maxdepth)) {
+        progress_max_treedepth <- as.integer(cfg$maxdepth)
+      }
+    },
+    error = function(e) NULL
+  )
+
   if (resolved_progress %in% c("cli", "text")) {
     print_sampling_diagnostic_summary(
       attr(draws, "diagnostics"),
@@ -319,7 +347,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
     )
   }
 
-  if (isTRUE(save_warmup) && !is.null(raw$warmup_draws)) {
+  if (save_warmup && !is.null(raw$warmup_draws)) {
     warmup <- matrix_to_draws_array(raw$warmup_draws, num_warmup, num_chains)
     attr(draws, "warmup_draws") <- warmup
     attr(draws, "warmup_diagnostics") <- reindex_diagnostics(
@@ -341,6 +369,13 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   draws
 }
 
+check_flag <- function(x, name) {
+  if (!is.logical(x) || length(x) != 1L || is.na(x)) {
+    stop(sprintf("`%s` must be TRUE or FALSE.", name), call. = FALSE)
+  }
+  x
+}
+
 opt_double <- function(x, name) {
   if (is.null(x)) return(NULL)
   if (!is.numeric(x) || length(x) != 1L || !is.finite(x)) {
@@ -358,6 +393,9 @@ check_count <- function(x, name, min = 0L, max = NULL) {
   if (!is.numeric(x) || !is.finite(x)) {
     stop(sprintf("`%s` must be a finite integer.", name), call. = FALSE)
   }
+  if (is.null(max)) {
+    max <- .Machine$integer.max
+  }
   # Bounds-check before the integer cast: values outside the i32 range
   # coerce to `NA` via `as.integer()`, which would otherwise produce a
   # confusing "missing value where TRUE/FALSE needed" error from the
@@ -366,7 +404,7 @@ check_count <- function(x, name, min = 0L, max = NULL) {
     stop(sprintf("`%s` must be >= %d; got %s.", name, min, format(x)),
          call. = FALSE)
   }
-  if (!is.null(max) && x > max) {
+  if (x > max) {
     stop(sprintf("`%s` must be <= %d; got %s.", name, max, format(x)),
          call. = FALSE)
   }
@@ -375,6 +413,31 @@ check_count <- function(x, name, min = 0L, max = NULL) {
          call. = FALSE)
   }
   as.integer(x)
+}
+
+check_optional_count <- function(x, name, min = 0L, max = NULL) {
+  if (is.null(x)) return(NULL)
+  check_count(x, name, min = min, max = max)
+}
+
+check_optional_positive <- function(x, name) {
+  if (is.null(x)) return(NULL)
+  x <- opt_double(x, name)
+  if (x <= 0) {
+    stop(sprintf("`%s` must be > 0; got %s.", name, format(x)),
+         call. = FALSE)
+  }
+  x
+}
+
+check_optional_probability <- function(x, name) {
+  if (is.null(x)) return(NULL)
+  x <- opt_double(x, name)
+  if (x <= 0 || x >= 1) {
+    stop(sprintf("`%s` must be in (0, 1); got %s.", name, format(x)),
+         call. = FALSE)
+  }
+  x
 }
 
 resolve_model <- function(model) {

--- a/R/sample.R
+++ b/R/sample.R
@@ -226,10 +226,12 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   extra_doublings <- check_optional_count(extra_doublings, "extra_doublings", min = 0L)
   target_accept <- check_optional_probability(target_accept, "target_accept")
   max_energy_error <- check_optional_positive(max_energy_error, "max_energy_error")
-  mass_matrix_gamma <- check_optional_positive(mass_matrix_gamma, "mass_matrix_gamma")
-  mass_matrix_eigval_cutoff <- check_optional_positive(
-    mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"
-  )
+  if (identical(adaptation, "low_rank")) {
+    mass_matrix_gamma <- check_optional_positive(mass_matrix_gamma, "mass_matrix_gamma")
+    mass_matrix_eigval_cutoff <- check_optional_positive(
+      mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"
+    )
+  }
 
   if (is.null(cores)) {
     cores <- min(num_chains, parallel::detectCores())
@@ -325,20 +327,20 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   attr(draws, "num_draws") <- num_draws
   attr(draws, "sampler_config") <- rename_sampler_config(raw$sampler_config)
 
-  # Use the sampler's effective maxdepth for %-at-cap advice, falling back to
-  # nuts-rs's documented default only when the config is unreadable.
-  progress_max_treedepth <- 10L
-  tryCatch(
-    {
-      cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"), simplifyVector = TRUE)
-      if (!is.null(cfg$maxdepth)) {
-        progress_max_treedepth <- as.integer(cfg$maxdepth)
-      }
-    },
-    error = function(e) NULL
-  )
-
   if (resolved_progress %in% c("cli", "text")) {
+    # Use the sampler's effective maxdepth for %-at-cap advice, falling back to
+    # nuts-rs's documented default only when the config is unreadable.
+    progress_max_treedepth <- 10L
+    tryCatch(
+      {
+        cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"), simplifyVector = TRUE)
+        if (!is.null(cfg$maxdepth)) {
+          progress_max_treedepth <- as.integer(cfg$maxdepth)
+        }
+      },
+      error = function(e) NULL
+    )
+
     print_sampling_diagnostic_summary(
       attr(draws, "diagnostics"),
       num_chains = num_chains,

--- a/R/sample.R
+++ b/R/sample.R
@@ -190,54 +190,51 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
                           mass_matrix_eigval_cutoff = NULL) {
   lib_path <- resolve_model(model)
   data_json <- resolve_data(data)
-  if (is.null(seed)) {
-    seed <- sample.int(.Machine$integer.max, 1L)
-  } else {
-    seed <- check_count(seed, "seed", min = 0L, max = .Machine$integer.max)
-  }
-  adaptation <- match.arg(adaptation)
-  if (identical(adaptation, "low-rank")) adaptation <- "low_rank"
-  progress <- match.arg(progress)
-  low_rank_modified_mass_matrix <- check_flag(
-    low_rank_modified_mass_matrix, "low_rank_modified_mass_matrix"
+  cfg <- resolve_sample_config(
+    seed = seed,
+    adaptation = adaptation,
+    low_rank_modified_mass_matrix = low_rank_modified_mass_matrix,
+    progress = progress,
+    save_warmup = save_warmup,
+    include = include,
+    store_divergences = store_divergences,
+    store_mass_matrix = store_mass_matrix,
+    store_unconstrained = store_unconstrained,
+    store_gradient = store_gradient,
+    num_draws = num_draws,
+    num_warmup = num_warmup,
+    num_chains = num_chains,
+    refresh = refresh,
+    cores = cores,
+    max_treedepth = max_treedepth,
+    mindepth = mindepth,
+    extra_doublings = extra_doublings,
+    target_accept = target_accept,
+    max_energy_error = max_energy_error,
+    mass_matrix_gamma = mass_matrix_gamma,
+    mass_matrix_eigval_cutoff = mass_matrix_eigval_cutoff
   )
-  save_warmup <- check_flag(save_warmup, "save_warmup")
-  include <- check_flag(include, "include")
-  store_divergences <- check_flag(store_divergences, "store_divergences")
-  store_mass_matrix <- check_flag(store_mass_matrix, "store_mass_matrix")
-  store_unconstrained <- check_flag(store_unconstrained, "store_unconstrained")
-  store_gradient <- check_flag(store_gradient, "store_gradient")
-
-  if (low_rank_modified_mass_matrix) {
-    warning(
-      "`low_rank_modified_mass_matrix` is deprecated; use ",
-      "`adaptation = \"low_rank\"` instead. ",
-      "`low_rank_modified_mass_matrix` will be removed in a future version.",
-      call. = FALSE
-    )
-    adaptation <- "low_rank"
-  }
-  num_draws <- check_count(num_draws, "num_draws", min = 1L)
-  num_warmup <- check_count(num_warmup, "num_warmup", min = 0L)
-  num_chains <- check_count(num_chains, "num_chains", min = 1L)
-  refresh <- check_count(refresh, "refresh", min = 0L)
-  max_treedepth <- check_optional_count(max_treedepth, "max_treedepth", min = 1L)
-  mindepth <- check_optional_count(mindepth, "mindepth", min = 0L)
-  extra_doublings <- check_optional_count(extra_doublings, "extra_doublings", min = 0L)
-  target_accept <- check_optional_probability(target_accept, "target_accept")
-  max_energy_error <- check_optional_positive(max_energy_error, "max_energy_error")
-  if (identical(adaptation, "low_rank")) {
-    mass_matrix_gamma <- check_optional_positive(mass_matrix_gamma, "mass_matrix_gamma")
-    mass_matrix_eigval_cutoff <- check_optional_positive(
-      mass_matrix_eigval_cutoff, "mass_matrix_eigval_cutoff"
-    )
-  }
-
-  if (is.null(cores)) {
-    cores <- min(num_chains, parallel::detectCores())
-    if (is.na(cores)) cores <- 1L
-  }
-  cores <- check_count(cores, "cores", min = 1L)
+  seed <- cfg$seed
+  adaptation <- cfg$adaptation
+  progress <- cfg$progress
+  save_warmup <- cfg$save_warmup
+  include <- cfg$include
+  store_divergences <- cfg$store_divergences
+  store_mass_matrix <- cfg$store_mass_matrix
+  store_unconstrained <- cfg$store_unconstrained
+  store_gradient <- cfg$store_gradient
+  num_draws <- cfg$num_draws
+  num_warmup <- cfg$num_warmup
+  num_chains <- cfg$num_chains
+  refresh <- cfg$refresh
+  cores <- cfg$cores
+  max_treedepth <- cfg$max_treedepth
+  mindepth <- cfg$mindepth
+  extra_doublings <- cfg$extra_doublings
+  target_accept <- cfg$target_accept
+  max_energy_error <- cfg$max_energy_error
+  mass_matrix_gamma <- cfg$mass_matrix_gamma
+  mass_matrix_eigval_cutoff <- cfg$mass_matrix_eigval_cutoff
 
   handle <- bs_open(lib_path, data_json, as.integer(seed))
   init_resolved <- resolve_init(init, init_mean, handle, num_chains,
@@ -319,6 +316,26 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
     },
     call_sample_stan(NULL)
   )
+  draws <- assemble_sample_result(
+    raw,
+    num_draws = num_draws,
+    num_warmup = num_warmup,
+    num_chains = num_chains,
+    save_warmup = save_warmup
+  )
+  maybe_print_sampling_summary(
+    draws,
+    raw,
+    resolved_progress = resolved_progress,
+    num_chains = num_chains
+  )
+  warn_on_expand_errors(raw$expand_errors %||% 0L)
+
+  draws
+}
+
+assemble_sample_result <- function(raw, num_draws, num_warmup, num_chains,
+                                   save_warmup) {
   draws <- matrix_to_draws_array(raw$draws, num_draws, num_chains)
   attr(draws, "diagnostics") <- reindex_diagnostics(raw$diagnostics,
                                                     num_warmup, "sample")
@@ -327,28 +344,6 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   attr(draws, "num_draws") <- num_draws
   attr(draws, "sampler_config") <- rename_sampler_config(raw$sampler_config)
 
-  if (resolved_progress %in% c("cli", "text")) {
-    # Use the sampler's effective maxdepth for %-at-cap advice, falling back to
-    # nuts-rs's documented default only when the config is unreadable.
-    progress_max_treedepth <- 10L
-    tryCatch(
-      {
-        cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"), simplifyVector = TRUE)
-        if (!is.null(cfg$maxdepth)) {
-          progress_max_treedepth <- as.integer(cfg$maxdepth)
-        }
-      },
-      error = function(e) NULL
-    )
-
-    print_sampling_diagnostic_summary(
-      attr(draws, "diagnostics"),
-      num_chains = num_chains,
-      elapsed = attr(raw, "progress_elapsed") %||% 0,
-      max_treedepth = progress_max_treedepth
-    )
-  }
-
   if (save_warmup && !is.null(raw$warmup_draws)) {
     warmup <- matrix_to_draws_array(raw$warmup_draws, num_warmup, num_chains)
     attr(draws, "warmup_draws") <- warmup
@@ -356,19 +351,148 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
       raw$warmup_diagnostics, num_warmup, "warmup"
     )
   }
+  draws
+}
 
-  n_expand_errors <- raw$expand_errors %||% 0L
-  if (n_expand_errors > 0L) {
-    warning(
-      n_expand_errors, " draw(s) had generated quantities that could not be ",
-      "computed (filled with NaN). This typically happens when the sampler ",
-      "explores extreme unconstrained values where parameter constraints ",
-      "(e.g. bounds) are violated during transformation.",
-      call. = FALSE
-    )
+maybe_print_sampling_summary <- function(draws, raw, resolved_progress, num_chains) {
+  if (!resolved_progress %in% c("cli", "text")) return(invisible(NULL))
+  print_sampling_diagnostic_summary(
+    attr(draws, "diagnostics"),
+    num_chains = num_chains,
+    elapsed = attr(raw, "progress_elapsed") %||% 0,
+    max_treedepth = progress_max_treedepth(attr(draws, "sampler_config"))
+  )
+}
+
+progress_max_treedepth <- function(sampler_config_json) {
+  # Use the sampler's effective maxdepth for %-at-cap advice, falling back to
+  # nuts-rs's documented default only when the config is unreadable.
+  out <- 10L
+  tryCatch(
+    {
+      cfg <- jsonlite::fromJSON(sampler_config_json, simplifyVector = TRUE)
+      if (!is.null(cfg$maxdepth)) {
+        out <- as.integer(cfg$maxdepth)
+      }
+    },
+    error = function(e) NULL
+  )
+  out
+}
+
+warn_on_expand_errors <- function(n_expand_errors) {
+  if (n_expand_errors <= 0L) return(invisible(NULL))
+  warning(
+    n_expand_errors, " draw(s) had generated quantities that could not be ",
+    "computed (filled with NaN). This typically happens when the sampler ",
+    "explores extreme unconstrained values where parameter constraints ",
+    "(e.g. bounds) are violated during transformation.",
+    call. = FALSE
+  )
+}
+
+resolve_sample_config <- function(seed, adaptation, low_rank_modified_mass_matrix,
+                                  progress, save_warmup, include,
+                                  store_divergences, store_mass_matrix,
+                                  store_unconstrained, store_gradient,
+                                  num_draws, num_warmup, num_chains, refresh,
+                                  cores, max_treedepth, mindepth,
+                                  extra_doublings, target_accept,
+                                  max_energy_error, mass_matrix_gamma,
+                                  mass_matrix_eigval_cutoff) {
+  if (is.null(seed)) {
+    seed <- sample.int(.Machine$integer.max, 1L)
+  } else {
+    seed <- check_count(seed, "seed", min = 0L, max = .Machine$integer.max)
   }
 
-  draws
+  adaptation <- match.arg(adaptation, c("diag", "low_rank", "low-rank"))
+  if (identical(adaptation, "low-rank")) adaptation <- "low_rank"
+  progress <- match.arg(progress, c("auto", "cli", "text", "none"))
+
+  low_rank_modified_mass_matrix <- check_flag(
+    low_rank_modified_mass_matrix, "low_rank_modified_mass_matrix"
+  )
+  if (low_rank_modified_mass_matrix) {
+    warning(
+      "`low_rank_modified_mass_matrix` is deprecated; use ",
+      "`adaptation = \"low_rank\"` instead. ",
+      "`low_rank_modified_mass_matrix` will be removed in a future version.",
+      call. = FALSE
+    )
+    adaptation <- "low_rank"
+  }
+
+  num_draws <- check_count(num_draws, "num_draws", min = 1L)
+  num_warmup <- check_count(num_warmup, "num_warmup", min = 0L)
+  num_chains <- check_count(num_chains, "num_chains", min = 1L)
+  refresh <- check_count(refresh, "refresh", min = 0L)
+  if (is.null(cores)) {
+    cores <- min(num_chains, parallel::detectCores())
+    if (is.na(cores)) cores <- 1L
+  }
+  cores <- check_count(cores, "cores", min = 1L)
+
+  tuning <- validate_tuning_options(
+    adaptation = adaptation,
+    max_treedepth = max_treedepth,
+    mindepth = mindepth,
+    extra_doublings = extra_doublings,
+    target_accept = target_accept,
+    max_energy_error = max_energy_error,
+    mass_matrix_gamma = mass_matrix_gamma,
+    mass_matrix_eigval_cutoff = mass_matrix_eigval_cutoff
+  )
+
+  c(
+    list(
+      seed = seed,
+      adaptation = adaptation,
+      progress = progress,
+      save_warmup = check_flag(save_warmup, "save_warmup"),
+      include = check_flag(include, "include"),
+      store_divergences = check_flag(store_divergences, "store_divergences"),
+      store_mass_matrix = check_flag(store_mass_matrix, "store_mass_matrix"),
+      store_unconstrained = check_flag(store_unconstrained, "store_unconstrained"),
+      store_gradient = check_flag(store_gradient, "store_gradient"),
+      num_draws = num_draws,
+      num_warmup = num_warmup,
+      num_chains = num_chains,
+      refresh = refresh,
+      cores = cores
+    ),
+    tuning
+  )
+}
+
+validate_tuning_options <- function(adaptation, ...) {
+  values <- list(...)
+  specs <- list(
+    max_treedepth = list(type = "count", min = 1L, applies = "all"),
+    mindepth = list(type = "count", min = 0L, applies = "all"),
+    extra_doublings = list(type = "count", min = 0L, applies = "all"),
+    target_accept = list(type = "probability", applies = "all"),
+    max_energy_error = list(type = "positive", applies = "all"),
+    mass_matrix_gamma = list(type = "positive", applies = "low_rank"),
+    mass_matrix_eigval_cutoff = list(type = "positive", applies = "low_rank")
+  )
+  lapply(names(specs), function(name) {
+    spec <- specs[[name]]
+    if (!identical(spec$applies, "all") && !identical(spec$applies, adaptation)) {
+      return(NULL)
+    }
+    check_tuning_option(values[[name]], name, spec)
+  }) |>
+    stats::setNames(names(specs))
+}
+
+check_tuning_option <- function(x, name, spec) {
+  switch(spec$type,
+    count = check_optional_count(x, name, min = spec$min),
+    positive = check_optional_positive(x, name),
+    probability = check_optional_probability(x, name),
+    stop("Unknown sampler option type: ", spec$type, call. = FALSE)
+  )
 }
 
 check_flag <- function(x, name) {

--- a/benchmarks/result_assembly_benchmark.R
+++ b/benchmarks/result_assembly_benchmark.R
@@ -1,0 +1,162 @@
+# Benchmark R-side result assembly on posteriorDB models.
+#
+# This isolates the post-Rust conversion path by tracing assemble_sample_result():
+#   raw Arrow/Rust result -> posterior::draws_array + diagnostics/warmup attrs.
+#
+# Usage:
+#   devtools::load_all(quiet = TRUE)
+#   source("benchmarks/result_assembly_benchmark.R")
+#   res <- run_result_assembly_benchmark()
+#
+# The defaults intentionally use a small but nontrivial posteriorDB subset so the
+# script is useful in PR loops. Increase num_draws/num_warmup for release-scale
+# memory checks.
+
+run_result_assembly_benchmark <- function(
+    posteriors = c(
+      "eight_schools-eight_schools_noncentered",
+      "diamonds-diamonds",
+      "irt_2pl-irt_2pl"
+    ),
+    num_draws = 100L,
+    num_warmup = 100L,
+    num_chains = 2L,
+    seed = 20260614L,
+    save_warmup = FALSE,
+    sample_args = list(),
+    results_dir = file.path("benchmarks", "results"),
+    output_csv = file.path(results_dir, "result_assembly_benchmark.csv")) {
+  stopifnot(requireNamespace("posteriordb", quietly = TRUE))
+  stopifnot(requireNamespace("posterior", quietly = TRUE))
+
+  dir.create(results_dir, recursive = TRUE, showWarnings = FALSE)
+  pdb <- posteriordb::pdb_default()
+  rows <- lapply(posteriors, benchmark_result_assembly_one,
+                 pdb = pdb,
+                 num_draws = num_draws,
+                 num_warmup = num_warmup,
+                 num_chains = num_chains,
+                 seed = seed,
+                 save_warmup = save_warmup,
+                 sample_args = sample_args)
+  out <- do.call(rbind, rows)
+  utils::write.csv(out, output_csv, row.names = FALSE)
+  message("Wrote ", output_csv)
+  out
+}
+
+benchmark_result_assembly_one <- function(posterior_name, pdb, num_draws,
+                                          num_warmup, num_chains, seed,
+                                          save_warmup, sample_args = list()) {
+  message("[", posterior_name, "] compile/sample")
+  po <- posteriordb::posterior(posterior_name, pdb)
+  stan_file <- tempfile(fileext = ".stan")
+  writeLines(posteriordb::stan_code(po), stan_file)
+  on.exit(unlink(stan_file), add = TRUE)
+
+  data <- posteriordb::pdb_data(po)
+  model <- nutpie_compile_model(stan_file, verbose = 0L)
+
+  assembly <- new.env(parent = emptyenv())
+  assembly$elapsed_s <- NA_real_
+  assembly$alloc_bytes <- NA_real_
+  assembly$alloc_events <- NA_integer_
+  assembly$memfile <- tempfile("nutpier-assembly-profmem-", fileext = ".out")
+  assign(".nutpier_assembly_bench_env", assembly, envir = globalenv())
+  on.exit(rm(".nutpier_assembly_bench_env", envir = globalenv()), add = TRUE)
+  on.exit(unlink(assembly$memfile), add = TRUE)
+
+  trace(
+    "assemble_sample_result",
+    where = asNamespace("nutpieR"),
+    tracer = quote({
+      .nutpier_assembly_bench_env$start <- proc.time()[["elapsed"]]
+      utils::Rprofmem(.nutpier_assembly_bench_env$memfile)
+    }),
+    exit = quote({
+      utils::Rprofmem(NULL)
+      .nutpier_assembly_bench_env$elapsed_s <-
+        proc.time()[["elapsed"]] - .nutpier_assembly_bench_env$start
+      mem <- get("parse_rprofmem", envir = globalenv())(
+        .nutpier_assembly_bench_env$memfile
+      )
+      .nutpier_assembly_bench_env$alloc_bytes <- mem$bytes
+      .nutpier_assembly_bench_env$alloc_events <- mem$events
+    }),
+    print = FALSE
+  )
+  on.exit(untrace("assemble_sample_result", where = asNamespace("nutpieR")), add = TRUE)
+
+  sample_start <- proc.time()[["elapsed"]]
+  err <- NULL
+  draws <- tryCatch(
+    do.call(
+      nutpie_sample,
+      c(
+        list(
+          model = model,
+          data = data,
+          num_draws = num_draws,
+          num_warmup = num_warmup,
+          num_chains = num_chains,
+          seed = seed,
+          refresh = 0L,
+          progress = "none",
+          save_warmup = save_warmup
+        ),
+        sample_args
+      )
+    ),
+    error = function(e) {
+      err <<- conditionMessage(e)
+      NULL
+    }
+  )
+  sample_elapsed_s <- proc.time()[["elapsed"]] - sample_start
+
+  if (is.null(draws)) {
+    return(data.frame(
+      posterior = posterior_name,
+      ok = FALSE,
+      error = err,
+      variables = NA_integer_,
+      draws = num_draws,
+      chains = num_chains,
+      save_warmup = save_warmup,
+      sample_args = paste(names(sample_args), unlist(sample_args, use.names = FALSE),
+                          sep = "=", collapse = ";"),
+      sample_elapsed_s = sample_elapsed_s,
+      assembly_elapsed_s = assembly$elapsed_s,
+      assembly_alloc_mb = assembly$alloc_bytes / 1024^2,
+      assembly_alloc_events = assembly$alloc_events,
+      draws_object_mb = NA_real_,
+      stringsAsFactors = FALSE
+    ))
+  }
+
+  data.frame(
+    posterior = posterior_name,
+    ok = TRUE,
+    error = NA_character_,
+    variables = length(posterior::variables(draws)),
+    draws = num_draws,
+    chains = num_chains,
+    save_warmup = save_warmup,
+    sample_args = paste(names(sample_args), unlist(sample_args, use.names = FALSE),
+                        sep = "=", collapse = ";"),
+    sample_elapsed_s = sample_elapsed_s,
+    assembly_elapsed_s = assembly$elapsed_s,
+    assembly_alloc_mb = assembly$alloc_bytes / 1024^2,
+    assembly_alloc_events = assembly$alloc_events,
+    draws_object_mb = as.numeric(utils::object.size(draws)) / 1024^2,
+    stringsAsFactors = FALSE
+  )
+}
+
+parse_rprofmem <- function(path) {
+  if (!file.exists(path)) return(list(bytes = NA_real_, events = NA_integer_))
+  lines <- readLines(path, warn = FALSE)
+  bytes <- suppressWarnings(as.numeric(sub(" .*", "", lines)))
+  bytes <- bytes[is.finite(bytes)]
+  list(bytes = sum(bytes), events = length(bytes))
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -42,6 +42,21 @@ fn pump_r_events() {
     }
 }
 
+/// Read and clear a pending R interrupt. Returns `true` if one was pending; the
+/// caller should then return a clean `Err` so extendr raises a normal R error
+/// at the call site ("Sampling interrupted.") rather than longjmp'ing past the
+/// in-flight `Sampler` teardown.
+fn interrupt_pending() -> bool {
+    unsafe {
+        if R_interrupts_pending != 0 {
+            R_interrupts_pending = 0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
 mod model;
 
 /// Convert any Display error to an extendr Error. Uses anyhow's alternate
@@ -217,19 +232,24 @@ fn run_sampler<S: Settings>(
             SamplerWaitResult::Trace(traces) => break traces,
             SamplerWaitResult::Timeout(s) => {
                 sampler_opt = Some(s);
-                // Check interrupt BEFORE calling back into R. Clear the flag and
-                // return a normal Err so extendr raises a clean R error at the
-                // call site ("Sampling interrupted."), rather than longjmp'ing past
-                // the assignment and leaving the user with a confusing "object not
-                // found" on the next line.
-                if unsafe { R_interrupts_pending != 0 } {
-                    unsafe { R_interrupts_pending = 0 };
+                // Check interrupt BEFORE calling back into R, so extendr raises a
+                // clean R error at the call site ("Sampling interrupted.") rather
+                // than longjmp'ing past the assignment and leaving the user with a
+                // confusing "object not found" on the next line.
+                if interrupt_pending() {
                     return Err(Error::Other("Sampling interrupted.".into()));
                 }
                 // Repaint the front-end console each poll so progress streams
                 // live instead of appearing all at once when sampling ends
                 // (GitHub #34: RStudio buffers native-call output).
                 pump_r_events();
+                // pump_r_events() suspends interrupts, so R_ProcessEvents() can
+                // latch a pending interrupt without longjmp'ing. Re-check before
+                // the R progress callback runs, or it could service the flag by
+                // longjmp'ing across these Rust frames.
+                if interrupt_pending() {
+                    return Err(Error::Other("Sampling interrupted.".into()));
+                }
                 let state_snapshot: Vec<ChainState> = {
                     let state = progress_state.lock().unwrap();
                     state.clone()

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -95,9 +95,17 @@ fn compile_stan_model_impl(
     let bs_path = bridgestan::download_bridgestan_src().map_err(r_err)?;
     let stan_path = PathBuf::from(stan_file);
 
-    let stanc_vec: Vec<String> = stanc_args.iter().map(|s| s.to_string()).collect();
+    let stanc_vec: Vec<String> = if stanc_args.is_empty() {
+        Vec::new()
+    } else {
+        stanc_args.iter().map(|s| s.to_string()).collect()
+    };
     let stanc_refs: Vec<&str> = stanc_vec.iter().map(String::as_str).collect();
-    let compile_vec: Vec<String> = compile_args.iter().map(|s| s.to_string()).collect();
+    let compile_vec: Vec<String> = if compile_args.is_empty() {
+        Vec::new()
+    } else {
+        compile_args.iter().map(|s| s.to_string()).collect()
+    };
     let compile_refs: Vec<&str> = compile_vec.iter().map(String::as_str).collect();
 
     let lib_path = bridgestan::compile_model(&bs_path, &stan_path, &stanc_refs, &compile_refs)
@@ -319,6 +327,7 @@ fn build_progress_snapshot(state: &[ChainState]) -> List {
 /// @return A named list with draws matrix, num_warmup, num_chains, diagnostics,
 ///   sampler_config (JSON), and optionally warmup_draws and warmup_diagnostics.
 /// @noRd
+#[allow(clippy::too_many_arguments)]
 #[extendr]
 fn sample_stan(
     handle: ExternalPtr<model::BSHandle>,
@@ -582,7 +591,7 @@ fn opt_finite_f64(robj: &Robj, name: &str) -> Result<Option<f64>> {
 fn opt_finite_positive_f64(robj: &Robj, name: &str) -> Result<Option<f64>> {
     let v = opt_finite_f64(robj, name)?;
     if let Some(x) = v {
-        if !(x > 0.0) {
+        if x <= 0.0 {
             return Err(Error::Other(format!("`{}` must be > 0, got {}.", name, x)));
         }
     }
@@ -592,7 +601,7 @@ fn opt_finite_positive_f64(robj: &Robj, name: &str) -> Result<Option<f64>> {
 fn opt_finite_in_open_unit(robj: &Robj, name: &str) -> Result<Option<f64>> {
     let v = opt_finite_f64(robj, name)?;
     if let Some(x) = v {
-        if !(x > 0.0 && x < 1.0) {
+        if x <= 0.0 || x >= 1.0 {
             return Err(Error::Other(format!(
                 "`{}` must be in (0, 1), got {}.",
                 name, x
@@ -635,7 +644,13 @@ fn run_with_settings<S: Settings + serde::Serialize>(
 ) -> Result<(Vec<ArrowTrace>, String)> {
     let json = serde_json::to_string(&settings)
         .map_err(|e| Error::Other(format!("failed to serialize sampler settings: {}", e)))?;
-    let traces = run_sampler(stan_model, settings, num_cores, save_warmup, progress_callback)?;
+    let traces = run_sampler(
+        stan_model,
+        settings,
+        num_cores,
+        save_warmup,
+        progress_callback,
+    )?;
     Ok((traces, json))
 }
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -18,6 +18,28 @@ use std::time::Duration;
 
 extern "C" {
     static mut R_interrupts_pending: std::os::raw::c_int;
+    static mut R_interrupts_suspended: std::os::raw::c_int;
+    // Pump R's event loop. Front-ends (RStudio, Positron) buffer console output
+    // produced during a blocking native call and only repaint when R processes
+    // events, so without this the progress callback's output is invisible until
+    // sample_stan() returns. See `pump_r_events`.
+    fn R_ProcessEvents();
+}
+
+/// Flush front-end consoles mid-sampling by pumping R's event loop.
+///
+/// Interrupts are suspended across the call: on Unix `R_ProcessEvents` longjmps
+/// (via `onintr`) when an interrupt is pending, which would skip the Rust
+/// `Sampler` teardown and corrupt the in-flight result. Suspending lets it
+/// flush output without jumping; the pending flag is left set and handled at the
+/// top of the poll loop, which returns a clean error there instead.
+fn pump_r_events() {
+    unsafe {
+        let prev = R_interrupts_suspended;
+        R_interrupts_suspended = 1;
+        R_ProcessEvents();
+        R_interrupts_suspended = prev;
+    }
 }
 
 mod model;
@@ -204,6 +226,10 @@ fn run_sampler<S: Settings>(
                     unsafe { R_interrupts_pending = 0 };
                     return Err(Error::Other("Sampling interrupted.".into()));
                 }
+                // Repaint the front-end console each poll so progress streams
+                // live instead of appearing all at once when sampling ends
+                // (GitHub #34: RStudio buffers native-call output).
+                pump_r_events();
                 let state_snapshot: Vec<ChainState> = {
                     let state = progress_state.lock().unwrap();
                     state.clone()

--- a/src/rust/src/model.rs
+++ b/src/rust/src/model.rs
@@ -36,12 +36,14 @@ fn add_tbb_to_path() {
         .or_else(|_| std::env::var("HOME"))
         .ok()
         .map(PathBuf::from)
-        .or_else(|| dirs::home_dir());
+        .or_else(dirs::home_dir);
 
     let Some(home) = home else { return };
     // Search for any bridgestan-* directory (not hardcoded version)
     let bs_base = home.join(".bridgestan");
-    let Ok(entries) = std::fs::read_dir(&bs_base) else { return };
+    let Ok(entries) = std::fs::read_dir(&bs_base) else {
+        return;
+    };
 
     for entry in entries.flatten() {
         let tbb_dir = entry
@@ -67,7 +69,10 @@ fn add_tbb_to_path() {
 }
 
 fn split_csv_names(s: &str) -> Vec<String> {
-    s.split(',').filter(|s| !s.is_empty()).map(String::from).collect()
+    s.split(',')
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
 }
 
 /// Opened BridgeStan model + cached parameter-name metadata.
@@ -97,10 +102,10 @@ impl BSHandle {
             Some(CString::new(data_json)?)
         };
         let mut model = bridgestan::Model::new(lib, data.as_deref(), seed)?;
-        let block_names = split_csv_names(&model.param_names(false, false));
-        let block_tp_names = split_csv_names(&model.param_names(true, false));
-        let full_names = split_csv_names(&model.param_names(true, true));
-        let unc_names = split_csv_names(&model.param_unc_names());
+        let block_names = split_csv_names(model.param_names(false, false));
+        let block_tp_names = split_csv_names(model.param_names(true, false));
+        let full_names = split_csv_names(model.param_names(true, true));
+        let unc_names = split_csv_names(model.param_unc_names());
         let ndim_unc = model.param_unc_num();
         let ndim_block = model.param_num(false, false);
         let ndim_block_tp = model.param_num(true, false);
@@ -158,7 +163,9 @@ mod tests {
         let joined = std::env::var_os("PATH").unwrap();
         let paths: Vec<PathBuf> = std::env::split_paths(&joined).collect();
         assert_eq!(paths.first(), Some(&tbb_dir));
-        assert!(paths.iter().any(|p| p == PathBuf::from("/usr/bin").as_path()));
+        assert!(paths
+            .iter()
+            .any(|p| p == PathBuf::from("/usr/bin").as_path()));
         assert!(paths.iter().any(|p| p == PathBuf::from("/bin").as_path()));
 
         if let Some(v) = old_home {
@@ -272,7 +279,7 @@ impl StanModel {
         include_gq: bool,
     ) -> anyhow::Result<Self> {
         anyhow::ensure!(
-            !(!include_tp && include_gq),
+            include_tp || !include_gq,
             "include_tp must be true when include_gq is true (GQ may reference TP)"
         );
         let (num_constrained, names) = match (include_tp, include_gq) {
@@ -325,10 +332,7 @@ impl StanModel {
 impl Model for StanModel {
     type Math<'model> = CpuMath<StanDensity<'model>>;
 
-    fn math<R: rand::Rng + ?Sized>(
-        &self,
-        rng: &mut R,
-    ) -> anyhow::Result<Self::Math<'_>> {
+    fn math<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> anyhow::Result<Self::Math<'_>> {
         // Claim a chain id for this worker thread. See MY_CHAIN_ID doc comment.
         let chain_id = self.chain_counter.fetch_add(1, Ordering::SeqCst);
         MY_CHAIN_ID.with(|c| c.set(Some(chain_id)));

--- a/tests/testthat/test-compile-cache.R
+++ b/tests/testthat/test-compile-cache.R
@@ -127,6 +127,30 @@ test_that("cache = FALSE compiles to a fresh tempdir, leaves cache untouched", {
   expect_equal(counter$n, 2L)
 })
 
+test_that("compile validates cache and verbose arguments", {
+  local_isolated_cache()
+  counter <- new.env(parent = emptyenv())
+  testthat::local_mocked_bindings(
+    compile_stan_model = make_compile_stub(counter),
+    bs_version = function() "TEST.0",
+    bridgestan_version = function() "TEST.0",
+    .package = "nutpieR"
+  )
+
+  stan <- make_temp_stan()
+  on.exit(unlink(dirname(stan), recursive = TRUE), add = TRUE)
+
+  expect_error(
+    nutpie_compile_model(stan_file = stan, verbose = NA_integer_),
+    "verbose"
+  )
+  expect_error(
+    nutpie_compile_model(stan_file = stan, cache = "false", verbose = 0L),
+    "cache"
+  )
+  expect_equal(counter$n, 0L)
+})
+
 test_that("inline cache: hit, miss on content/flags, clear wipes", {
   local_isolated_cache()
   counter <- new.env(parent = emptyenv())

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -99,6 +99,18 @@ test_that("nutpie_sample validates logical and optional tuning arguments in R", 
                   max_energy_error = 0, refresh = 0),
     "max_energy_error"
   )
+  expect_error(
+    nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                  adaptation = "low_rank", mass_matrix_gamma = 0, refresh = 0),
+    "mass_matrix_gamma"
+  )
+  expect_s3_class(
+    nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                  num_draws = 10, num_warmup = 10, num_chains = 1,
+                  seed = 1L, refresh = 0, adaptation = "diag",
+                  mass_matrix_gamma = 0, mass_matrix_eigval_cutoff = 0),
+    "draws_array"
+  )
 })
 
 test_that("cores defaults to 1 when detectCores returns NA", {

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -45,6 +45,7 @@ test_that("check_count rejects malformed counts", {
   expect_error(nutpieR:::check_count(NA_integer_, "num_chains"), "num_chains")
   expect_error(nutpieR:::check_count(1.5, "num_warmup"), "num_warmup")
   expect_error(nutpieR:::check_count(c(1L, 2L), "num_chains"), "num_chains")
+  expect_error(nutpieR:::check_count(2^32, "num_draws"), "must be <=")
 })
 
 test_that("check_count enforces optional max", {
@@ -73,6 +74,30 @@ test_that("nutpie_sample rejects malformed target_accept", {
     nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
                   target_accept = 1.5),
     "target_accept"
+  )
+})
+
+test_that("nutpie_sample validates logical and optional tuning arguments in R", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  expect_error(
+    nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                  save_warmup = "yes", refresh = 0),
+    "save_warmup"
+  )
+  expect_error(
+    nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                  include = NA, refresh = 0),
+    "include"
+  )
+  expect_error(
+    nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                  mindepth = 1.5, refresh = 0),
+    "mindepth"
+  )
+  expect_error(
+    nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                  max_energy_error = 0, refresh = 0),
+    "max_energy_error"
   )
 })
 

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -21,16 +21,25 @@ test_that("progress mode falls back to text when cli is unavailable", {
 })
 
 test_that("cli is enabled interactively but disabled while knitting", {
-  withr::local_options(knitr.in.progress = NULL)
-  expect_true(nutpieR:::should_use_cli_progress(interactive = TRUE))
-  expect_false(nutpieR:::should_use_cli_progress(interactive = FALSE))
+  # `knitting` is injected rather than set via `options(knitr.in.progress=)`:
+  # setting that real option makes testthat load knitr mid-test, which is a
+  # cyclic namespace load under `R CMD check` (see GitHub #34 build failures).
+  expect_true(
+    nutpieR:::should_use_cli_progress(interactive = TRUE, knitting = FALSE)
+  )
+  expect_false(
+    nutpieR:::should_use_cli_progress(interactive = FALSE, knitting = FALSE)
+  )
 
-  withr::local_options(knitr.in.progress = TRUE)
-  expect_false(nutpieR:::should_use_cli_progress(interactive = TRUE))
+  expect_false(
+    nutpieR:::should_use_cli_progress(interactive = TRUE, knitting = TRUE)
+  )
   expect_equal(
     nutpieR:::resolve_progress_mode(
       "auto", refresh = 100L,
-      use_cli = nutpieR:::should_use_cli_progress(interactive = TRUE)
+      use_cli = nutpieR:::should_use_cli_progress(
+        interactive = TRUE, knitting = TRUE
+      )
     ),
     "text"
   )


### PR DESCRIPTION
1.8.2 was initially an efficiency/validation pass that never actually made it off my machine; this PR ships it, bundled with a fix for the progress-reporting regression John reported in #34.

## Progress is back in RStudio and Positron (#34)

The last commit on 1.8 had a subtle bug with the idea to respect suppressMessages for progress callbacks — that turned out to silence live progress in some IDE consoles. There were two distinct causes, one per front-end:

- **Positron** installs a global `message` handler (via ark) that redirects output to the console and invokes the `muffleMessage` restart. Our suppressMessages probe couldn't distinguish that from a real `suppressMessages()`, so it muted everything. The fix treats "a global message handler is present" as not-suppressed and lets the callback emit. Trade-off: `suppressMessages()` no longer silences *live* progress under such a handler; the start banner and end summary, emitted at the R top level, still go quiet normally.
- **RStudio** buffers console output produced during a blocking native call and only repaints when R pumps its event loop — which our Rust poll loop never did. Added a `R_ProcessEvents()` pump once per ~200ms poll, with interrupts suspended around it so a pending Ctrl-C can't longjmp past the Sampler teardown (the existing top-of-loop check still handles the interrupt cleanly).

## Clean `R CMD check` again

The binary builds were erroring on r-universe:

- a test set `options(knitr.in.progress = TRUE)`, which made testthat `loadNamespace("knitr")` mid-test — a cyclic namespace load under check. The test now injects a `knitting` argument instead of touching the global option.

## The 1.8.2 efficiency/validation pass (the rest of the diff)

- R-side argument validation for `nutpie_sample()`/`nutpie_compile_model()`: bad flags and out-of-range tuning values fail fast with a clear message instead of silently coercing.
- Fixed a debug-build abort on empty `stanc`/`make` arg vectors.
- Treedepth-cap advice reads the effective `max_treedepth` from `sampler_config` instead of assuming `10`.
- Single-sourced the divergence-severity / E-BFMI warning text so the post-run summary and `nutpie_diagnostics()` can't drift; made the status-token formatter table-driven.
- Refactor of `R/sample.R` (config resolution and result assembly pulled into helpers) plus a result-assembly benchmark.

## Testing

Since I missed this regression in that last commit of 1.8.0, I've added some new validation passes using a wider variety of IDE environments. This should ensure this doesn't happen again
