### PR TITLE
Fix macOS progress-callback segfaults by dropping tbbmalloc_proxy (#36)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.8.2
+Version: 1.8.3
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# nutpieR 1.8.3
+
+* Fixed macOS segfaults during progress reporting on large models (GitHub
+  #36) by compiling with `TBB_LIBRARIES=tbb`, dropping Stan's process-wide
+  `tbbmalloc_proxy` allocator. Override via `compile_args = "TBB_LIBRARIES=..."`.
+
 # nutpieR 1.8.2
 
 * Live sampling progress streams in the RStudio and Positron consoles again

--- a/R/compile.R
+++ b/R/compile.R
@@ -46,7 +46,11 @@
 #' @param stanc_args Character vector of extra arguments passed to the
 #'   `stanc` compiler (e.g., `"--O1"` for optimization).
 #' @param compile_args Character vector of extra arguments passed to `make`
-#'   during compilation.
+#'   during compilation. On macOS, nutpieR compiles with
+#'   `TBB_LIBRARIES=tbb` by default (matching Linux and Windows) to avoid
+#'   linking Stan's process-wide `tbbmalloc_proxy` allocator, which can
+#'   crash R during live progress reporting (GitHub #36). Pass an explicit
+#'   `"TBB_LIBRARIES=..."` here to override this default.
 #' @param verbose Integer controlling compilation output. `0` = silent,
 #'   `1` (default) = print status messages.
 #'   Note: full make/stanc output (verbose=2) is not yet supported because
@@ -102,6 +106,8 @@ nutpie_compile_model <- function(stan_file = NULL, code = NULL,
   use_cache <- cache &&
     !identical(Sys.getenv("NUTPIER_DISABLE_COMPILE_CACHE"), "1")
 
+  compile_args <- effective_compile_args(compile_args)
+
   bundle <- if (!is.null(code)) {
     inline_bundle(code)
   } else {
@@ -113,6 +119,36 @@ nutpie_compile_model <- function(stan_file = NULL, code = NULL,
   } else {
     compile_no_cache(bundle, stanc_args, compile_args, verbose)
   }
+}
+
+# Resolve the make arguments actually used to compile, layering in
+# platform defaults over the caller's `compile_args`.
+#
+# On macOS, Stan's makefile links the TBB scalable-allocator proxy
+# (`tbbmalloc_proxy`) into every model `.so` by default; Linux and Windows
+# link plain `tbb` (stan_math `make/compiler_flags`). The proxy installs
+# itself as the *process-wide* allocator via a macOS malloc zone, so R's
+# own allocations route through it. Freeing an R-allocated, page-aligned
+# block then faults inside TBB's `__TBB_malloc_safer_msize` (it reads the
+# block header at `ptr - 4`, which for such a foreign pointer lands on an
+# unmapped guard page) -- which is exactly what the live-progress callback
+# triggers when it frees R memory mid-sample on large models (GitHub #36).
+#
+# Pin `TBB_LIBRARIES=tbb` on macOS to match the other platforms, unless the
+# caller has explicitly set it (e.g. to opt back into the proxy). This is
+# applied here, above the cache layer, so the flag is folded into the
+# compile-cache key: existing proxy-linked artifacts get a fresh key and
+# are recompiled rather than silently reused.
+#
+# `sysname` is a parameter so the platform branch is unit-testable.
+effective_compile_args <- function(compile_args,
+                                   sysname = Sys.info()[["sysname"]]) {
+  compile_args <- as.character(compile_args)
+  if (identical(sysname, "Darwin") &&
+      !any(grepl("^\\s*TBB_LIBRARIES", compile_args))) {
+    compile_args <- c(compile_args, "TBB_LIBRARIES=tbb")
+  }
+  compile_args
 }
 
 #' @export

--- a/man/nutpie_compile_model.Rd
+++ b/man/nutpie_compile_model.Rd
@@ -23,7 +23,11 @@ nutpie_compile_model(
 \code{stanc} compiler (e.g., \code{"--O1"} for optimization).}
 
 \item{compile_args}{Character vector of extra arguments passed to \code{make}
-during compilation.}
+during compilation. On macOS, nutpieR compiles with
+\code{TBB_LIBRARIES=tbb} by default (matching Linux and Windows) to avoid
+linking Stan's process-wide \code{tbbmalloc_proxy} allocator, which can
+crash R during live progress reporting (GitHub #36). Pass an explicit
+\code{"TBB_LIBRARIES=..."} here to override this default.}
 
 \item{verbose}{Integer controlling compilation output. \code{0} = silent,
 \code{1} (default) = print status messages.

--- a/tests/testthat/test-tbb-allocator.R
+++ b/tests/testthat/test-tbb-allocator.R
@@ -1,0 +1,76 @@
+# Regression coverage for GitHub #36: on macOS, Stan links the
+# `tbbmalloc_proxy` allocator into model `.so`s by default, which crashes R
+# during live progress reporting. nutpieR pins `TBB_LIBRARIES=tbb` on macOS
+# to drop the proxy (matching Linux/Windows), unless the caller overrides it.
+
+test_that("effective_compile_args drops the TBB malloc proxy on macOS", {
+  expect_identical(
+    nutpieR:::effective_compile_args(character(), sysname = "Darwin"),
+    "TBB_LIBRARIES=tbb"
+  )
+  # Existing user args are preserved; the default is appended.
+  expect_identical(
+    nutpieR:::effective_compile_args("STANCFLAGS=foo", sysname = "Darwin"),
+    c("STANCFLAGS=foo", "TBB_LIBRARIES=tbb")
+  )
+})
+
+test_that("effective_compile_args is a no-op off macOS", {
+  for (os in c("Linux", "Windows")) {
+    expect_identical(
+      nutpieR:::effective_compile_args(character(), sysname = os),
+      character()
+    )
+    expect_identical(
+      nutpieR:::effective_compile_args("STANCFLAGS=foo", sysname = os),
+      "STANCFLAGS=foo"
+    )
+  }
+})
+
+test_that("a caller-supplied TBB_LIBRARIES overrides the macOS default", {
+  # Opting back into the proxy must be respected, and must not be
+  # double-appended.
+  proxy <- "TBB_LIBRARIES=tbb tbbmalloc tbbmalloc_proxy"
+  expect_identical(
+    nutpieR:::effective_compile_args(proxy, sysname = "Darwin"),
+    proxy
+  )
+  expect_identical(
+    nutpieR:::effective_compile_args("TBB_LIBRARIES=tbb", sysname = "Darwin"),
+    "TBB_LIBRARIES=tbb"
+  )
+})
+
+test_that("the macOS default vs. proxy land in different cache slots", {
+  # Folding the flag in above the cache layer is what invalidates stale
+  # proxy-linked artifacts compiled by older nutpieR versions.
+  v <- "TEST.0"
+  bundle <- nutpieR:::inline_bundle("data {}")
+  default <- nutpieR:::effective_compile_args(character(), sysname = "Darwin")
+  proxy <- nutpieR:::effective_compile_args(
+    "TBB_LIBRARIES=tbb tbbmalloc tbbmalloc_proxy", sysname = "Darwin")
+  expect_false(
+    nutpieR:::cache_key(bundle, v, character(), default) ==
+      nutpieR:::cache_key(bundle, v, character(), proxy)
+  )
+})
+
+test_that("compiled macOS models do not link tbbmalloc_proxy", {
+  skip_on_cran()
+  skip_if_not(Sys.info()[["sysname"]] == "Darwin", "macOS-only linkage check")
+  skip_if(Sys.which("otool") == "", "otool not available")
+  skip_if_not(
+    identical(Sys.getenv("NUTPIER_RUN_SLOW_TESTS"), "1"),
+    "slow: compiles a Stan model"
+  )
+
+  model <- nutpie_compile_model(
+    code = "parameters { real x; } model { x ~ normal(0, 1); }",
+    verbose = 0L
+  )
+  deps <- system2("otool", c("-L", shQuote(model$lib_path)), stdout = TRUE)
+  tbb <- grep("tbb", deps, value = TRUE)
+  expect_true(any(grepl("libtbb\\.dylib", tbb)))      # threading still linked
+  expect_false(any(grepl("tbbmalloc_proxy", tbb)))    # proxy dropped (#36)
+})


### PR DESCRIPTION
## Summary

Fixes #36: on macOS, sampling with `progress = "cli"`/`"text"` segfaults a few draws in (`address ... cause 'invalid permissions'`), especially on large models, high `max_treedepth`, or low-rank mass matrix. `progress = "none"` avoids it; 1.7 was unaffected.

## Issue

Stan's makefile links the TBB scalable-allocator proxy (`tbbmalloc_proxy`) into every model `.so` **on macOS only** (Linux/Windows link plain `tbb`). The proxy installs itself as the **process-wide** allocator via a macOS malloc zone, so R's own allocations route through it. Freeing an R-allocated, **page-aligned** block then faults inside TBB's `__TBB_malloc_safer_msize`, which reads the block header at `ptr - 4` — for such a foreign pointer that lands on an unmapped guard page. 

## Fix

Compile with `TBB_LIBRARIES=tbb` on macOS (the documented Stan override; what Linux/Windows already use), dropping the proxy. TBB threading is unaffected. Callers can opt back into the proxy via `compile_args = "TBB_LIBRARIES=tbb tbbmalloc tbbmalloc_proxy"`.

I'd like to find a solution that doesn't require turning off the proxy flag, since it does 

## Verification

I build a large (~300k param) model that would consistently cause the crash, and confirmed it no longer does after this PR.

