### PR TITLE
Release 1.8.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.8.4
+Version: 1.8.5
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# nutpieR (development version)
+# nutpieR 1.8.5
 
 * `nutpie_prune_cache()` now rejects negative, fractional, non-finite, or
   non-scalar pruning arguments before touching the cache.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# nutpieR (development version)
+
+* `nutpie_prune_cache()` now rejects negative, fractional, non-finite, or
+  non-scalar pruning arguments before touching the cache.
+* `num_warmup = NULL` now uses the adaptation-specific default: 400 for
+  diagonal and 800 for low-rank adaptation.
+* `nutpie_diagnostics()` notes when R-hat and ESS cover a `pars`-filtered set of
+  returned variables.
+* Fixed live treedepth inference and max-treedepth fallback detection.
+* Live progress now marks inferred treedepth with `~`.
+* Added per-entry locking for concurrent compile-cache misses.
+* Expansion failures now retain valid parameter values and fill unavailable
+  transformed parameters or generated quantities with `NaN`.
+* macOS sampling now stops before opening a model when an unpatched
+  `tbbmalloc_proxy` is loaded.
+
 # nutpieR 1.8.4
 
 * macOS: fixed the intermittent segfaults during sampling and garbage

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,11 @@
   opening a model when an unpatched `tbbmalloc_proxy` is loaded.
 * `num_warmup = NULL` now follows the adaptation-specific default: 400 for
   diagonal and 800 for low-rank adaptation.
-* Clearer diagnostics and failure handling: fixed live treedepth inference,
-  marked inferred progress depth with `~`, clarified `pars`-filtered R-hat/ESS,
-  and retained valid parameter values when output expansion fails.
+* Clearer diagnostics and failure handling: fixed live treedepth inference
+  (`2^depth - 1` leapfrog steps for a complete tree; the old display could be
+  one level low), marked inferred progress depth with `~`, clarified
+  `pars`-filtered R-hat/ESS, and retained valid parameter values when output
+  expansion fails.
 
 # nutpieR 1.8.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,13 @@
 # nutpieR 1.8.5
 
-* `nutpie_prune_cache()` now rejects negative, fractional, non-finite, or
-  non-scalar pruning arguments before touching the cache.
-* `num_warmup = NULL` now uses the adaptation-specific default: 400 for
+* Safer compilation and sampling: concurrent cache misses now use per-entry
+  locking, cache-pruning inputs are validated, and macOS sampling stops before
+  opening a model when an unpatched `tbbmalloc_proxy` is loaded.
+* `num_warmup = NULL` now follows the adaptation-specific default: 400 for
   diagonal and 800 for low-rank adaptation.
-* `nutpie_diagnostics()` notes when R-hat and ESS cover a `pars`-filtered set of
-  returned variables.
-* Fixed live treedepth inference and max-treedepth fallback detection.
-* Live progress now marks inferred treedepth with `~`.
-* Added per-entry locking for concurrent compile-cache misses.
-* Expansion failures now retain valid parameter values and fill unavailable
-  transformed parameters or generated quantities with `NaN`.
-* macOS sampling now stops before opening a model when an unpatched
-  `tbbmalloc_proxy` is loaded.
+* Clearer diagnostics and failure handling: fixed live treedepth inference,
+  marked inferred progress depth with `~`, clarified `pars`-filtered R-hat/ESS,
+  and retained valid parameter values when output expansion fails.
 
 # nutpieR 1.8.4
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -241,6 +241,67 @@ entry_lib_path  <- function(entry, main_rel) {
          "_model.so")
 }
 
+# A cache key may be requested by several R processes at once (e.g. parallel
+# CI jobs sharing R_USER_CACHE_DIR). `dir.create()` is atomic on supported
+# local filesystems, so a sibling lock directory serialises staging and
+# compiling of one entry without serialising unrelated models. A stale lock
+# from a killed process is reclaimed after half a day; an active compiler
+# should finish well before then, while a waiter times out with an actionable
+# error rather than blocking indefinitely.
+CACHE_LOCK_TIMEOUT_SECS <- 600
+CACHE_LOCK_STALE_SECS <- 12 * 60 * 60
+
+entry_lock_path <- function(entry) paste0(entry, ".lock")
+
+with_cache_entry_lock <- function(entry, expr,
+                                  timeout_secs = CACHE_LOCK_TIMEOUT_SECS,
+                                  stale_secs = CACHE_LOCK_STALE_SECS) {
+  lock <- entry_lock_path(entry)
+  started <- Sys.time()
+  repeat {
+    if (dir.create(lock, showWarnings = FALSE)) break
+
+    info <- file.info(lock)
+    age <- as.numeric(difftime(Sys.time(), info$mtime, units = "secs"))
+    if (dir.exists(lock) && is.finite(age) && age > stale_secs) {
+      unlink(lock, recursive = TRUE, force = TRUE)
+      next
+    }
+    waited <- as.numeric(difftime(Sys.time(), started, units = "secs"))
+    if (!is.finite(waited) || waited >= timeout_secs) {
+      stop(
+        "Timed out waiting for another process to compile the same cached ",
+        "Stan model. If no compilation is running, remove stale lock: ", lock,
+        call. = FALSE
+      )
+    }
+    Sys.sleep(0.05)
+  }
+  on.exit(unlink(lock, recursive = TRUE, force = TRUE), add = TRUE)
+  force(expr)
+}
+
+cached_model <- function(entry, main_rel, display_source, verbose) {
+  ok <- entry_ok_marker(entry)
+  main <- entry_main_path(entry, main_rel)
+  lib <- entry_lib_path(entry, main_rel)
+  if (!file.exists(ok) || !file.exists(lib) || !file.exists(main)) {
+    return(NULL)
+  }
+  if (verbose >= 1L) message("Using cached compiled model.")
+  # A cache hit never calls into Rust, so ensure_safe_tbb_proxy (which only
+  # runs during a real compile) would never re-patch a stale, unpatched
+  # tbbmalloc_proxy for an upgrading user whose model is already cached.
+  ensure_tbb_proxy_patched()
+  # Marker mtime is the LRU timestamp for pruning.
+  Sys.setFileTime(ok, Sys.time())
+  nutpie_model(
+    lib_path = normalizePath(lib, mustWork = TRUE),
+    stan_file = display_source,
+    staged_source = normalizePath(main, mustWork = TRUE)
+  )
+}
+
 # --- Compile --------------------------------------------------------------
 
 nutpie_model <- function(lib_path, stan_file, staged_source) {
@@ -332,54 +393,46 @@ compile_at_path <- function(stan_file, stanc_args, compile_args, verbose) {
 compile_via_cache <- function(bundle, stanc_args, compile_args, verbose) {
   key <- cache_key(bundle, bs_version(), stanc_args, compile_args)
   entry <- file.path(cache_root(), key)
-  ok    <- entry_ok_marker(entry)
-  main  <- entry_main_path(entry, bundle$main)
-  lib   <- entry_lib_path(entry, bundle$main)
 
-  if (file.exists(ok) && file.exists(lib) && file.exists(main)) {
-    if (verbose >= 1L) message("Using cached compiled model.")
-    # A cache hit never calls into Rust, so ensure_safe_tbb_proxy (which only
-    # runs during a real compile) would never re-patch a stale, unpatched
-    # tbbmalloc_proxy for an upgrading user whose model is already cached. Do it
-    # here: macOS-cheap, idempotent, no-op elsewhere, and never triggers a
-    # BridgeStan download (GitHub #36).
-    ensure_tbb_proxy_patched()
-    # Refresh the `ok` mtime so this entry counts as recently-used.
-    # Pruning is LRU on the marker mtime; without the bump, a popular
-    # but old-on-disk model could be auto-evicted right after a hit
-    # returns it to the caller (issue surfaced in PR #24 review).
-    Sys.setFileTime(ok, Sys.time())
-    return(nutpie_model(
-      lib_path      = normalizePath(lib,  mustWork = TRUE),
-      stan_file     = bundle$display_source,
-      staged_source = normalizePath(main, mustWork = TRUE)
-    ))
-  }
+  # Fast path: a complete entry is immutable, so it is safe to use without
+  # taking the per-key compile lock.
+  hit <- cached_model(entry, bundle$main, bundle$display_source, verbose)
+  if (!is.null(hit)) return(hit)
 
-  # Wipe partial state from a prior failed compile so stage_bundle()
-  # starts from a clean slate.
-  if (dir.exists(entry)) {
-    unlink(entry, recursive = TRUE, force = TRUE)
-  }
-  stage_bundle(bundle, entry)
-  built <- compile_at_path(
-    entry_main_path(entry, bundle$main),
-    stanc_args, compile_args, verbose
-  )
-  file.create(ok)
+  # A waiter must check again after it owns the lock: the prior lock holder may
+  # have completed the same build while this process waited.
+  with_cache_entry_lock(entry, {
+    hit <- cached_model(entry, bundle$main, bundle$display_source, verbose)
+    if (!is.null(hit)) {
+      hit
+    } else {
+      # Wipe partial state from a prior failed compile so stage_bundle() starts
+      # from a clean slate. The lock prevents another process from observing or
+      # changing this entry until the `ok` marker is written.
+      if (dir.exists(entry)) {
+        unlink(entry, recursive = TRUE, force = TRUE)
+      }
+      stage_bundle(bundle, entry)
+      built <- compile_at_path(
+        entry_main_path(entry, bundle$main),
+        stanc_args, compile_args, verbose
+      )
+      file.create(entry_ok_marker(entry))
 
-  tryCatch(
-    prune_cache_internal(CACHE_MAX_ENTRIES, CACHE_MIN_AGE_DAYS),
-    error = function(e) NULL
-  )
+      tryCatch(
+        prune_cache_internal(CACHE_MAX_ENTRIES, CACHE_MIN_AGE_DAYS),
+        error = function(e) NULL
+      )
 
-  nutpie_model(
-    lib_path      = normalizePath(built, mustWork = TRUE),
-    stan_file     = bundle$display_source,
-    staged_source = normalizePath(
-      entry_main_path(entry, bundle$main), mustWork = TRUE
-    )
-  )
+      nutpie_model(
+        lib_path = normalizePath(built, mustWork = TRUE),
+        stan_file = bundle$display_source,
+        staged_source = normalizePath(
+          entry_main_path(entry, bundle$main), mustWork = TRUE
+        )
+      )
+    }
+  })
 }
 
 # cache = FALSE escape hatch: stage + compile in a fresh tempdir,
@@ -443,18 +496,29 @@ prune_cache_internal <- function(max_entries, min_age_days) {
 #' here for one-off manual cleanup or scripted maintenance.
 #'
 #' @param max_entries Maximum number of valid (fully compiled) cache
-#'   entries to retain. Defaults to 16.
+#'   entries to retain. Must be a non-negative whole number. Defaults to 16.
 #' @param min_age_days Minimum age (in days, by `ok` marker mtime) before
-#'   an entry is eligible for eviction. Defaults to 14, so frequently
-#'   re-used models aren't evicted just because the cache is hot.
+#'   an entry is eligible for eviction. Must be a non-negative finite number.
+#'   Defaults to 14, so frequently re-used models aren't evicted just because
+#'   the cache is hot.
 #' @return Invisibly, the number of entries removed.
 #' @examples
 #' nutpie_prune_cache()
 #' nutpie_prune_cache(max_entries = 8, min_age_days = 7)
 #' @export
 nutpie_prune_cache <- function(max_entries = 16L, min_age_days = 14L) {
+  max_entries <- check_count(max_entries, "max_entries", min = 0L)
+  if (length(min_age_days) != 1L) {
+    stop("`min_age_days` must be a single non-negative finite number.",
+         call. = FALSE)
+  }
+  if (!is.numeric(min_age_days) || !is.finite(min_age_days) ||
+      min_age_days < 0) {
+    stop("`min_age_days` must be a non-negative finite number.",
+         call. = FALSE)
+  }
   invisible(prune_cache_internal(
-    as.integer(max_entries), as.numeric(min_age_days)
+    max_entries, as.numeric(min_age_days)
   ))
 }
 

--- a/R/compile.R
+++ b/R/compile.R
@@ -49,9 +49,11 @@
 #'   during compilation. On macOS, nutpieR keeps Stan's fast process-wide
 #'   `tbbmalloc_proxy` allocator but patches its bundled source to be safe
 #'   (GitHub #36); this is automatic and idempotent. Set
-#'   `NUTPIER_NO_TBB_PROXY_PATCH=1` to skip the patch (nutpieR then gates live
-#'   progress at runtime instead), or pass `"TBB_LIBRARIES=tbb"` here to drop
-#'   the proxy entirely (safe, but ~17% slower on large, many-chain models).
+#'   `NUTPIER_NO_TBB_PROXY_PATCH=1` to skip the patch, or pass
+#'   `"TBB_LIBRARIES=tbb"` here to drop the proxy entirely (safe, but ~17%
+#'   slower on large, many-chain models). If an unpatched proxy is loaded,
+#'   nutpieR stops sampling and asks you to restart R because all subsequent R
+#'   allocations in that process are unsafe.
 #' @param verbose Integer controlling compilation output. `0` = silent,
 #'   `1` (default) = print status messages.
 #'   Note: full make/stanc output (verbose=2) is not yet supported because

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -201,7 +201,12 @@ nutpie_diagnostics <- function(draws) {
          call. = FALSE)
   }
   num_chains <- attr(draws, "num_chains") %||% dim(draws)[[2]] %||% 1L
-  out <- structure(diag, class = "nutpie_diagnostics", num_chains = num_chains)
+  out <- structure(
+    diag,
+    class = "nutpie_diagnostics",
+    num_chains = num_chains,
+    variables_filtered = isTRUE(attr(draws, "variables_filtered"))
+  )
   # Reference (not a copy) so print() can compute R-hat/ESS lazily; nothing is
   # computed here, so field access stays cheap.
   attr(out, "draws") <- draws
@@ -260,6 +265,9 @@ print.nutpie_diagnostics <- function(x, ...) {
     if (!is.null(rhat_ess$min_ess_tail)) {
       cat(sprintf("  Min Tail-ESS:  %.0f (%s)\n",
                   rhat_ess$min_ess_tail, rhat_ess$min_ess_tail_var))
+    }
+    if (isTRUE(attr(x, "variables_filtered"))) {
+      cat("  R-hat/ESS cover returned variables only (`pars` filtering was used).\n")
     }
   }
 

--- a/R/progress.R
+++ b/R/progress.R
@@ -33,26 +33,20 @@ resolve_progress_mode <- function(progress, refresh,
   )
 }
 
-#' Guard against a stale, unpatched macOS `tbbmalloc_proxy` (GitHub #36). If such
-#' an allocator is already loaded in this session, EVERY R allocation is at risk
-#' of a garbage-collection crash until R is restarted — not just live progress —
-#' so warn once regardless of `mode`. Rendering live progress additionally
-#' allocates mid-sample, so also downgrade `"cli"`/`"text"` to `"none"`. No-op
-#' when the loaded proxy carries nutpieR's page-safe patch, when no proxy is
-#' loaded, or off macOS (`tbb_proxy_live_progress_safe()` is `TRUE` in all those
-#' cases). `safe` is injectable for tests.
+#' Guard against a stale, unpatched macOS `tbbmalloc_proxy` (GitHub #36). Once
+#' loaded, every subsequent R allocation is at risk of a garbage-collection
+#' crash until R is restarted, including result assembly after sampling. Stop
+#' before sampling rather than merely disabling live progress. No-op when the
+#' loaded proxy carries nutpieR's page-safe patch, when no proxy is loaded, or
+#' off macOS (`tbb_proxy_live_progress_safe()` is `TRUE` in all those cases).
+#' `safe` is injectable for tests.
 #' @noRd
 gate_progress_for_tbb <- function(mode, safe = tbb_proxy_live_progress_safe()) {
   if (isTRUE(safe)) return(mode)
-  if (!isTRUE(getOption("nutpieR.tbb_gate_warned"))) {
-    cli::cli_warn(c(
-      "An unpatched Stan {.pkg tbbmalloc_proxy} allocator is already loaded in this session.",
-      "!" = "Until you restart R, every R allocation in this session risks a garbage-collection crash (GitHub #36), not just live progress.",
-      "i" = "Recompile the model with {.code cache = FALSE} to pick up the patched allocator, or compile with {.code compile_args = \"TBB_LIBRARIES=tbb\"} to drop the proxy entirely."
-    ))
-    options(nutpieR.tbb_gate_warned = TRUE)
-  }
-  if (mode %in% c("cli", "text")) "none" else mode
+  cli::cli_abort(c(
+    "An unpatched Stan {.pkg tbbmalloc_proxy} allocator is already loaded; sampling was stopped to avoid a garbage-collection crash (GitHub #36).",
+    "i" = "Restart R, then recompile with {.code cache = FALSE} to pick up the patch, or use {.code compile_args = \"TBB_LIBRARIES=tbb\"} to drop the proxy entirely."
+  ))
 }
 
 #' @noRd
@@ -146,7 +140,7 @@ format_divergence_status <- function(total_divs) {
 #' @noRd
 infer_tree_depth <- function(n_steps) {
   if (!is.finite(n_steps) || n_steps <= 0) return(NA_integer_)
-  as.integer(floor(log2(n_steps)))
+  as.integer(floor(log2(n_steps + 1)))
 }
 
 #' @noRd
@@ -178,11 +172,15 @@ format_gradient_status <- function(avg_lf) {
   }
 }
 
+#' Live estimate of the latest tree depth from its leapfrog count.
+#'
+#' The progress snapshot does not include nuts-rs's exact final tree depth.
+#' Diagnostics `$depth` remains authoritative after sampling.
 #' @noRd
 format_treedepth_status <- function(n_steps) {
   depth <- infer_tree_depth(as_progress_num(n_steps, NA_real_))
-  if (!is.finite(depth)) return("tdepth: -")
-  paste("tdepth:", depth)
+  if (!is.finite(depth)) return("tdepth: ~-")
+  paste0("tdepth: ~", depth)
 }
 
 #' @noRd
@@ -564,7 +562,7 @@ sampling_summary_table <- function(diagnostics) {
 #' Fraction of sampled draws that hit the max tree depth cap. Prefers nuts-rs's
 #' own `maxdepth_reached` flag — the same field `print.nutpie_diagnostics()`
 #' reports — so the two never disagree. Falls back to `depth >= max_treedepth`,
-#' then `n_steps >= 2^max_treedepth`, when that flag is absent. Returns `NA`
+#' then `n_steps >= 2^max_treedepth - 1`, when that flag is absent. Returns `NA`
 #' when none is available.
 #' @noRd
 fraction_at_treedepth_cap <- function(diagnostics, max_treedepth) {
@@ -575,7 +573,8 @@ fraction_at_treedepth_cap <- function(diagnostics, max_treedepth) {
   } else if (!is.null(diagnostics$depth)) {
     at_cap <- as.numeric(diagnostics$depth) >= as.numeric(max_treedepth)
   } else if (!is.null(diagnostics$n_steps)) {
-    at_cap <- as.numeric(diagnostics$n_steps) >= 2^as.numeric(max_treedepth)
+    at_cap <- as.numeric(diagnostics$n_steps) >=
+      2^as.numeric(max_treedepth) - 1
   } else {
     return(NA_real_)
   }

--- a/R/progress.R
+++ b/R/progress.R
@@ -444,7 +444,7 @@ progress_supports_color <- function() {
 #' Positron's R kernel (ark) registers a global `message` handler that redirects
 #' message output to the console and invokes the `muffleMessage` restart. That
 #' is a redirect, not suppression: it must not be mistaken for `suppressMessages()`
-#' (see [progress_messages_muffled()]). The query form of `globalCallingHandlers()`
+#' (see `progress_messages_muffled()`). The query form of `globalCallingHandlers()`
 #' is safe to call with handlers on the stack; only the *setting* form errors.
 #' @noRd
 has_global_message_handler <- function() {
@@ -672,7 +672,7 @@ print_sampling_diagnostic_summary <- function(diagnostics, num_chains, elapsed,
 #' most once per run; the trigger flags live here so both callbacks fire each
 #' hint exactly once. `cli_bar_id` is the active cli progress bar id (cli mode),
 #' so hints can coordinate with it; `NULL` in text mode (see
-#' [emit_progress_hint()]).
+#' `emit_progress_hint()`).
 #' @noRd
 new_progress_hints <- function(cli_bar_id = NULL) {
   env <- new.env(parent = emptyenv())

--- a/R/sample.R
+++ b/R/sample.R
@@ -10,15 +10,19 @@
 #'   - A path to a `.json` file
 #'   - `NULL` for models with no data block
 #' @param num_draws Number of post-warmup draws per chain.
-#' @param num_warmup Number of warmup (tuning) draws per chain.
+#' @param num_warmup Number of warmup (tuning) draws per chain. `NULL` (the
+#'   default) uses the nuts-rs adaptation-specific default: `400` for
+#'   `adaptation = "diag"` and `800` for `adaptation = "low_rank"`. An explicit
+#'   value always takes precedence.
 #' @param num_chains Number of parallel chains.
 #' @param seed Random seed for reproducibility.
-#' @param max_treedepth Maximum tree depth for NUTS. The number of leapfrog
-#'   steps per draw is at most `2^max_treedepth`. Default `NULL` keeps the
-#'   nuts-rs default (currently 10).
-#' @param mindepth Minimum tree depth for NUTS. The number of leapfrog steps
-#'   per draw is at least `2^mindepth`. Default `NULL` keeps the nuts-rs
-#'   default (currently 0).
+#' @param max_treedepth Maximum tree depth for NUTS. A complete tree at
+#'   depth `d` takes `2^d - 1` leapfrog steps. This is the ordinary depth cap;
+#'   `extra_doublings` can extend a trajectory after a turning point. Default
+#'   `NULL` keeps the nuts-rs default (currently 10).
+#' @param mindepth Minimum tree depth for NUTS. Absent an earlier divergence,
+#'   this requires at least `2^mindepth - 1` leapfrog steps. Default `NULL`
+#'   keeps the nuts-rs default (currently 0).
 #' @param target_accept Target acceptance probability for step size adaptation.
 #'   Default `NULL` keeps the nuts-rs default (currently 0.8).
 #' @param max_energy_error Energy-error threshold above which a leapfrog step
@@ -42,8 +46,9 @@
 #'   threshold), `{spread}` (percent-range spread across chains, e.g.
 #'   `spread 23-78%`, shown only once chains diverge enough), `{draws}`
 #'   (per-chain draw range), `{spark}` (gap-from-leader sparkline), `{lag}`
-#'   (slow chain indicator), `{step}` (min step size), `{tdepth}` (latest
-#'   treedepth). The default is `"{div} | {grad} | {spread}"`. For `"text"`
+#'   (slow chain indicator), `{step}` (min step size), `{tdepth}` (estimated
+#'   latest treedepth, prefixed with `~`). The default is
+#'   `"{div} | {grad} | {spread}"`. For `"text"`
 #'   mode, per-chain tokens are
 #'   also available: `{chain}`, `{phase}`, `{pct}`, `{draws}`, `{total}`,
 #'   `{elapsed}`, `{div}`, `{grad}`, `{tdepth}`. `NULL` uses the
@@ -116,6 +121,8 @@
 #'   will match `beta`, `beta[1]`, `beta[2]`, etc. When the kept set excludes
 #'   the entire transformed-parameter and/or generated-quantities blocks,
 #'   those slices are skipped at sample time (see `NEWS.md` for benchmarks).
+#'   R-hat and ESS reported by [nutpie_diagnostics()] then cover only the
+#'   variables retained in the returned draws.
 #' @param include Logical (default `TRUE`). If `TRUE`, `pars` specifies the
 #'   parameters to *keep* (whitelist). If `FALSE`, `pars` specifies parameters
 #'   to *exclude* (blacklist). Ignored when `pars` is `NULL`.
@@ -169,7 +176,7 @@
 #' }
 #' @export
 nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
-                          num_warmup = 400L, num_chains = 4L, seed = NULL,
+                          num_warmup = NULL, num_chains = 4L, seed = NULL,
                           max_treedepth = NULL, mindepth = NULL,
                           target_accept = NULL, max_energy_error = NULL,
                           extra_doublings = NULL,
@@ -188,6 +195,10 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
                           low_rank_modified_mass_matrix = FALSE,
                           mass_matrix_gamma = NULL,
                           mass_matrix_eigval_cutoff = NULL) {
+  # Fail before doing any model/data work when a stale macOS allocator is
+  # already present. Opening a model can load that allocator, so check again
+  # immediately after bs_open() below.
+  gate_progress_for_tbb("none")
   lib_path <- resolve_model(model)
   data_json <- resolve_data(data)
   cfg <- resolve_sample_config(
@@ -237,6 +248,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   mass_matrix_eigval_cutoff <- cfg$mass_matrix_eigval_cutoff
 
   handle <- bs_open(lib_path, data_json, as.integer(seed))
+  gate_progress_for_tbb("none")
   init_resolved <- resolve_init(init, init_mean, handle, num_chains,
                                 seed = seed)
 
@@ -246,7 +258,6 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
   keep_indices <- resolve_keep_indices(constrain_names, pars, include)
 
   resolved_progress <- resolve_progress_mode(progress, refresh)
-  resolved_progress <- gate_progress_for_tbb(resolved_progress)
   chain_format <- validate_chain_format(chain_format, resolved_progress)
   # Will be replaced with the effective maxdepth from sampler_config after sampling.
 
@@ -324,6 +335,7 @@ nutpie_sample <- function(model, data = NULL, num_draws = 1000L,
     num_chains = num_chains,
     save_warmup = save_warmup
   )
+  attr(draws, "variables_filtered") <- !is.null(pars)
   maybe_print_sampling_summary(
     draws,
     raw,
@@ -384,10 +396,11 @@ progress_max_treedepth <- function(sampler_config_json) {
 warn_on_expand_errors <- function(n_expand_errors) {
   if (n_expand_errors <= 0L) return(invisible(NULL))
   warning(
-    n_expand_errors, " draw(s) had generated quantities that could not be ",
-    "computed (filled with NaN). This typically happens when the sampler ",
-    "explores extreme unconstrained values where parameter constraints ",
-    "(e.g. bounds) are violated during transformation.",
+    n_expand_errors, " draw(s) had transformed parameters or generated ",
+    "quantities that could not be computed. nutpieR preserved any lower-level ",
+    "values that could be safely recomputed and filled unavailable outputs ",
+    "with NaN. Check transformed-parameter and generated-quantities code for ",
+    "invalid function domains, rejected values, or violated output bounds.",
     call. = FALSE
   )
 }
@@ -422,6 +435,10 @@ resolve_sample_config <- function(seed, adaptation, low_rank_modified_mass_matri
       call. = FALSE
     )
     adaptation <- "low_rank"
+  }
+
+  if (is.null(num_warmup)) {
+    num_warmup <- if (identical(adaptation, "low_rank")) 800L else 400L
   }
 
   num_draws <- check_count(num_draws, "num_draws", min = 1L)

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ draws <- nutpie_sample(
 ```
 
 (`low_rank_modified_mass_matrix = TRUE` still works but is deprecated.)
-Mass-matrix and warmup defaults inherit from nuts-rs; pass `num_warmup`
-explicitly to override.
+When `num_warmup` is omitted, nutpieR matches nuts-rs's adaptation-specific
+defaults: 400 warmup draws for diagonal adaptation and 800 for low-rank.
 
 ## How it works
 

--- a/man/nutpie_compile_model.Rd
+++ b/man/nutpie_compile_model.Rd
@@ -23,7 +23,14 @@ nutpie_compile_model(
 \code{stanc} compiler (e.g., \code{"--O1"} for optimization).}
 
 \item{compile_args}{Character vector of extra arguments passed to \code{make}
-during compilation.}
+during compilation. On macOS, nutpieR keeps Stan's fast process-wide
+\code{tbbmalloc_proxy} allocator but patches its bundled source to be safe
+(GitHub #36); this is automatic and idempotent. Set
+\code{NUTPIER_NO_TBB_PROXY_PATCH=1} to skip the patch, or pass
+\code{"TBB_LIBRARIES=tbb"} here to drop the proxy entirely (safe, but ~17\%
+slower on large, many-chain models). If an unpatched proxy is loaded,
+nutpieR stops sampling and asks you to restart R because all subsequent R
+allocations in that process are unsafe.}
 
 \item{verbose}{Integer controlling compilation output. \code{0} = silent,
 \code{1} (default) = print status messages.

--- a/man/nutpie_prune_cache.Rd
+++ b/man/nutpie_prune_cache.Rd
@@ -8,11 +8,12 @@ nutpie_prune_cache(max_entries = 16L, min_age_days = 14L)
 }
 \arguments{
 \item{max_entries}{Maximum number of valid (fully compiled) cache
-entries to retain. Defaults to 16.}
+entries to retain. Must be a non-negative whole number. Defaults to 16.}
 
 \item{min_age_days}{Minimum age (in days, by \code{ok} marker mtime) before
-an entry is eligible for eviction. Defaults to 14, so frequently
-re-used models aren't evicted just because the cache is hot.}
+an entry is eligible for eviction. Must be a non-negative finite number.
+Defaults to 14, so frequently re-used models aren't evicted just because
+the cache is hot.}
 }
 \value{
 Invisibly, the number of entries removed.

--- a/man/nutpie_sample.Rd
+++ b/man/nutpie_sample.Rd
@@ -8,7 +8,7 @@ nutpie_sample(
   model,
   data = NULL,
   num_draws = 1000L,
-  num_warmup = 400L,
+  num_warmup = NULL,
   num_chains = 4L,
   seed = NULL,
   max_treedepth = NULL,
@@ -49,19 +49,23 @@ or a path to a compiled shared library.}
 
 \item{num_draws}{Number of post-warmup draws per chain.}
 
-\item{num_warmup}{Number of warmup (tuning) draws per chain.}
+\item{num_warmup}{Number of warmup (tuning) draws per chain. \code{NULL} (the
+default) uses the nuts-rs adaptation-specific default: \code{400} for
+\code{adaptation = "diag"} and \code{800} for \code{adaptation = "low_rank"}. An explicit
+value always takes precedence.}
 
 \item{num_chains}{Number of parallel chains.}
 
 \item{seed}{Random seed for reproducibility.}
 
-\item{max_treedepth}{Maximum tree depth for NUTS. The number of leapfrog
-steps per draw is at most \code{2^max_treedepth}. Default \code{NULL} keeps the
-nuts-rs default (currently 10).}
+\item{max_treedepth}{Maximum tree depth for NUTS. A complete tree at
+depth \code{d} takes \code{2^d - 1} leapfrog steps. This is the ordinary depth cap;
+\code{extra_doublings} can extend a trajectory after a turning point. Default
+\code{NULL} keeps the nuts-rs default (currently 10).}
 
-\item{mindepth}{Minimum tree depth for NUTS. The number of leapfrog steps
-per draw is at least \code{2^mindepth}. Default \code{NULL} keeps the nuts-rs
-default (currently 0).}
+\item{mindepth}{Minimum tree depth for NUTS. Absent an earlier divergence,
+this requires at least \code{2^mindepth - 1} leapfrog steps. Default \code{NULL}
+keeps the nuts-rs default (currently 0).}
 
 \item{target_accept}{Target acceptance probability for step size adaptation.
 Default \code{NULL} keeps the nuts-rs default (currently 0.8).}
@@ -91,8 +95,9 @@ progress bar shows. Use \code{{token}} placeholders. Available tokens for
 threshold), \code{{spread}} (percent-range spread across chains, e.g.
 \verb{spread 23-78\%}, shown only once chains diverge enough), \code{{draws}}
 (per-chain draw range), \code{{spark}} (gap-from-leader sparkline), \code{{lag}}
-(slow chain indicator), \code{{step}} (min step size), \code{{tdepth}} (latest
-treedepth). The default is \code{"{div} | {grad} | {spread}"}. For \code{"text"}
+(slow chain indicator), \code{{step}} (min step size), \code{{tdepth}} (estimated
+latest treedepth, prefixed with \code{~}). The default is
+\code{"{div} | {grad} | {spread}"}. For \code{"text"}
 mode, per-chain tokens are
 also available: \code{{chain}}, \code{{phase}}, \code{{pct}}, \code{{draws}}, \code{{total}},
 \code{{elapsed}}, \code{{div}}, \code{{grad}}, \code{{tdepth}}. \code{NULL} uses the
@@ -151,7 +156,9 @@ output draws. By default (\code{NULL}), all parameters are returned. Parameter
 names should be the Stan block names, not indexed names — e.g. \code{"beta"}
 will match \code{beta}, \code{beta[1]}, \code{beta[2]}, etc. When the kept set excludes
 the entire transformed-parameter and/or generated-quantities blocks,
-those slices are skipped at sample time (see \code{NEWS.md} for benchmarks).}
+those slices are skipped at sample time (see \code{NEWS.md} for benchmarks).
+R-hat and ESS reported by \code{\link[=nutpie_diagnostics]{nutpie_diagnostics()}} then cover only the
+variables retained in the returned draws.}
 
 \item{include}{Logical (default \code{TRUE}). If \code{TRUE}, \code{pars} specifies the
 parameters to \emph{keep} (whitelist). If \code{FALSE}, \code{pars} specifies parameters

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -296,14 +296,12 @@ fn ensure_safe_tbb_proxy(bs_path: &std::path::Path, will_recompile: bool) {
     // Stan vendors TBB under lib/tbb_<version>/; the built objects and dylibs
     // land in lib/tbb/.
     let src_dir = match fs::read_dir(&lib) {
-        Ok(rd) => rd
-            .filter_map(|e| e.ok().map(|e| e.path()))
-            .find(|p| {
-                p.file_name()
-                    .and_then(|n| n.to_str())
-                    .map_or(false, |n| n.starts_with("tbb_"))
-                    && p.join("src/tbbmalloc/proxy_overload_osx.h").exists()
-            }),
+        Ok(rd) => rd.filter_map(|e| e.ok().map(|e| e.path())).find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("tbb_"))
+                && p.join("src/tbbmalloc/proxy_overload_osx.h").exists()
+        }),
         Err(_) => None,
     };
     let src_dir = match src_dir {
@@ -1624,9 +1622,11 @@ mod tests {
             "// preceding declarations\nstatic void impl_zone_destroy() {{}}\n\n{}\n\n// trailing declarations\n",
             TBB_STOCK_FN
         );
-        let patched =
-            patch_proxy_source(&fixture).expect("stock function must be found verbatim");
-        assert!(patched.contains(TBB_PATCH_MARKER), "marker symbol spliced in");
+        let patched = patch_proxy_source(&fixture).expect("stock function must be found verbatim");
+        assert!(
+            patched.contains(TBB_PATCH_MARKER),
+            "marker symbol spliced in"
+        );
         assert!(
             !patched.contains("malloc_default_zone"),
             "must not probe the virtual default zone (forwards back into us and recurses)"
@@ -1648,7 +1648,13 @@ mod tests {
 
     #[test]
     fn contains_bytes_finds_marker() {
-        assert!(contains_bytes(b"xxnutpie_tbb_proxy_safe_probeyy", TBB_PATCH_MARKER.as_bytes()));
-        assert!(!contains_bytes(b"unrelated bytes", TBB_PATCH_MARKER.as_bytes()));
+        assert!(contains_bytes(
+            b"xxnutpie_tbb_proxy_safe_probeyy",
+            TBB_PATCH_MARKER.as_bytes()
+        ));
+        assert!(!contains_bytes(
+            b"unrelated bytes",
+            TBB_PATCH_MARKER.as_bytes()
+        ));
     }
 }

--- a/src/rust/src/model.rs
+++ b/src/rust/src/model.rs
@@ -126,9 +126,19 @@ impl BSHandle {
 
 #[cfg(test)]
 mod tests {
-    use super::add_tbb_to_path;
+    use super::{add_tbb_to_path, expansion_fallbacks};
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn expansion_fallbacks_preserve_the_parameter_prefix_after_tp_failure() {
+        assert_eq!(
+            expansion_fallbacks(true, true, 2, 5),
+            vec![(true, 5), (false, 2)]
+        );
+        assert_eq!(expansion_fallbacks(true, false, 2, 5), vec![(false, 2)]);
+        assert!(expansion_fallbacks(false, false, 2, 5).is_empty());
+    }
 
     #[test]
     fn add_tbb_to_path_uses_platform_path_separator() {
@@ -229,6 +239,8 @@ pub struct StanModel {
     ndim: usize,
     include_tp: bool,
     include_gq: bool,
+    num_block: usize,
+    num_block_tp: usize,
     num_constrained: usize,
     constrained_param_names: Vec<String>,
     /// One position per chain. `len() == 1` means broadcast to all chains.
@@ -250,6 +262,8 @@ impl StanModel {
             ndim: handle.ndim_unc,
             include_tp: true,
             include_gq: true,
+            num_block: handle.ndim_block,
+            num_block_tp: handle.ndim_block_tp,
             num_constrained: handle.ndim_full,
             constrained_param_names: handle.full_names.clone(),
             init_positions: None,
@@ -375,6 +389,24 @@ impl Model for StanModel {
 
 // --- StanDensity: per-chain logp evaluator ---
 
+// On an expansion failure, retry the largest potentially valid output prefix
+// first. GQ can fail while parameters/TP are valid; TP can fail while the
+// parameters block remains valid.
+fn expansion_fallbacks(
+    include_tp: bool,
+    include_gq: bool,
+    num_block: usize,
+    num_block_tp: usize,
+) -> Vec<(bool, usize)> {
+    if include_gq {
+        vec![(true, num_block_tp), (false, num_block)]
+    } else if include_tp {
+        vec![(false, num_block)]
+    } else {
+        Vec::new()
+    }
+}
+
 pub struct StanDensity<'model> {
     model: &'model StanModel,
     rng: bridgestan::Rng<&'model bridgestan::StanLibrary>,
@@ -439,10 +471,36 @@ impl<'model> CpuLogpFunc for StanDensity<'model> {
         match result {
             Ok(()) => Ok(out),
             Err(_) => {
-                // param_constrain failed (e.g. generated quantities bounds violation).
-                // The draw itself is valid — fill expanded vector with NaN and continue.
+                // Expansion failures do not invalidate the sampled unconstrained
+                // position. Preserve the largest safe prefix by retrying without
+                // generated quantities (or without transformed parameters if TP
+                // itself failed), and leave only the unavailable suffix as NaN.
                 self.expand_errors.fetch_add(1, Ordering::Relaxed);
                 out.fill(f64::NAN);
+
+                // First omit GQ while retaining TP. If that fails too, TP
+                // itself is unavailable, so retry with only the parameters
+                // block. Each successful retry overwrites the longest valid
+                // prefix and leaves the unavailable suffix as NaN.
+                let fallbacks = expansion_fallbacks(
+                    include_tp,
+                    include_gq,
+                    self.model.num_block,
+                    self.model.num_block_tp,
+                );
+                for (fallback_tp, fallback_len) in fallbacks {
+                    let mut prefix = vec![0f64; fallback_len];
+                    let no_rng: Option<&mut bridgestan::Rng<&bridgestan::StanLibrary>> = None;
+                    if self
+                        .model
+                        .inner
+                        .param_constrain(array, fallback_tp, false, &mut prefix, no_rng)
+                        .is_ok()
+                    {
+                        out[..fallback_len].copy_from_slice(&prefix);
+                        break;
+                    }
+                }
                 Ok(out)
             }
         }

--- a/tests/testthat/helper-models.R
+++ b/tests/testthat/helper-models.R
@@ -34,6 +34,11 @@ test_models$tp_gq <- try_compile(
   stan_file = test_path("test_models", "tp_gq.stan")
 )
 
+test_models$gq_failure <- try_compile(
+  "gq_failure",
+  stan_file = test_path("test_models", "gq_failure.stan")
+)
+
 # Shared fixtures used by test-init.R, test-helpers.R, test-nutpieR.R.
 
 bernoulli_data <- function() {

--- a/tests/testthat/test-compile-cache.R
+++ b/tests/testthat/test-compile-cache.R
@@ -44,24 +44,26 @@ local_isolated_cache <- function(env = parent.frame()) {
 
 test_that("per-entry cache lock is released after success and failure", {
   entry <- tempfile("nutpieR-cache-lock-")
-  on.exit(unlink(entry_lock_path(entry), recursive = TRUE), add = TRUE)
+  on.exit(unlink(nutpieR:::entry_lock_path(entry), recursive = TRUE), add = TRUE)
 
-  expect_equal(with_cache_entry_lock(entry, 42L), 42L)
-  expect_false(dir.exists(entry_lock_path(entry)))
+  expect_equal(nutpieR:::with_cache_entry_lock(entry, 42L), 42L)
+  expect_false(dir.exists(nutpieR:::entry_lock_path(entry)))
 
-  expect_error(with_cache_entry_lock(entry, stop("expected failure")),
+  expect_error(nutpieR:::with_cache_entry_lock(entry, stop("expected failure")),
                "expected failure")
-  expect_false(dir.exists(entry_lock_path(entry)))
+  expect_false(dir.exists(nutpieR:::entry_lock_path(entry)))
 })
 
 test_that("per-entry cache lock reclaims a stale lock", {
   entry <- tempfile("nutpieR-cache-lock-")
-  lock <- entry_lock_path(entry)
+  lock <- nutpieR:::entry_lock_path(entry)
   dir.create(lock)
   on.exit(unlink(lock, recursive = TRUE), add = TRUE)
 
   expect_equal(
-    with_cache_entry_lock(entry, 42L, timeout_secs = 0, stale_secs = -1),
+    nutpieR:::with_cache_entry_lock(
+      entry, 42L, timeout_secs = 0, stale_secs = -1
+    ),
     42L
   )
   expect_false(dir.exists(lock))

--- a/tests/testthat/test-compile-cache.R
+++ b/tests/testthat/test-compile-cache.R
@@ -42,6 +42,31 @@ local_isolated_cache <- function(env = parent.frame()) {
   td
 }
 
+test_that("per-entry cache lock is released after success and failure", {
+  entry <- tempfile("nutpieR-cache-lock-")
+  on.exit(unlink(entry_lock_path(entry), recursive = TRUE), add = TRUE)
+
+  expect_equal(with_cache_entry_lock(entry, 42L), 42L)
+  expect_false(dir.exists(entry_lock_path(entry)))
+
+  expect_error(with_cache_entry_lock(entry, stop("expected failure")),
+               "expected failure")
+  expect_false(dir.exists(entry_lock_path(entry)))
+})
+
+test_that("per-entry cache lock reclaims a stale lock", {
+  entry <- tempfile("nutpieR-cache-lock-")
+  lock <- entry_lock_path(entry)
+  dir.create(lock)
+  on.exit(unlink(lock, recursive = TRUE), add = TRUE)
+
+  expect_equal(
+    with_cache_entry_lock(entry, 42L, timeout_secs = 0, stale_secs = -1),
+    42L
+  )
+  expect_false(dir.exists(lock))
+})
+
 test_that("cache_key folds in content, BridgeStan version, and flags", {
   v <- nutpieR:::bs_version()
   k_base <- nutpieR:::inline_cache_key("data {}", v, character(), character())
@@ -369,6 +394,23 @@ test_that("nutpie_prune_cache respects max_entries and min_age_days", {
   remaining <- basename(list.dirs(root, recursive = FALSE))
   expect_equal(length(remaining), 16L)
   expect_true(all(grepl("^new", remaining[order(remaining)][1:10])))
+})
+
+test_that("nutpie_prune_cache rejects invalid arguments before deleting", {
+  local_isolated_cache()
+  root <- nutpie_cache_dir()
+  entry <- file.path(root, "must-survive")
+  dir.create(entry, recursive = TRUE)
+  file.create(file.path(entry, "ok"))
+
+  expect_error(nutpie_prune_cache(max_entries = -1L), "max_entries")
+  expect_error(nutpie_prune_cache(max_entries = 1.5), "whole number")
+  expect_error(nutpie_prune_cache(max_entries = NA_real_), "finite integer")
+  expect_error(nutpie_prune_cache(min_age_days = -1), "min_age_days")
+  expect_error(nutpie_prune_cache(min_age_days = Inf), "finite")
+  expect_error(nutpie_prune_cache(min_age_days = c(1, 2)), "single")
+
+  expect_true(dir.exists(entry))
 })
 
 test_that("cache hit refreshes ok marker mtime (so prune treats it as LRU)", {

--- a/tests/testthat/test-diagnostics-print.R
+++ b/tests/testthat/test-diagnostics-print.R
@@ -8,7 +8,8 @@
 # well-mixed sigma, and attach a diagnostics attribute of the shape
 # nutpie_diagnostics() expects.
 make_diag_object <- function(mu_means, energy_pattern = "healthy",
-                             diverging = NULL, n_iter = 200L) {
+                             diverging = NULL, n_iter = 200L,
+                             variables_filtered = FALSE) {
   set.seed(42)
   n_chain <- length(mu_means)
   arr <- array(0, dim = c(n_iter, n_chain, 2L),
@@ -37,6 +38,7 @@ make_diag_object <- function(mu_means, energy_pattern = "healthy",
     energy           = energy
   )
   attr(draws, "num_chains") <- n_chain
+  attr(draws, "variables_filtered") <- variables_filtered
   nutpie_diagnostics(draws)
 }
 
@@ -50,6 +52,20 @@ test_that("print always shows Max R-hat / ESS / E-BFMI info lines", {
   expect_match(out, "posterior::summarize_draws(draws)", fixed = TRUE)
   # Developer field dump is gone.
   expect_false(grepl("Available fields", out, fixed = TRUE))
+})
+
+test_that("print notes when R-hat and ESS cover filtered variables", {
+  filtered <- make_diag_object(c(0, 0, 0, 0), variables_filtered = TRUE)
+  filtered_out <- paste(
+    capture.output(suppressMessages(print(filtered))), collapse = "\n"
+  )
+  expect_match(filtered_out, "R-hat/ESS cover returned variables only", fixed = TRUE)
+
+  unfiltered <- make_diag_object(c(0, 0, 0, 0))
+  unfiltered_out <- paste(
+    capture.output(suppressMessages(print(unfiltered))), collapse = "\n"
+  )
+  expect_false(grepl("returned variables only", unfiltered_out, fixed = TRUE))
 })
 
 test_that("a non-mixing (bimodal) fit flags R-hat/ESS and names the parameter", {

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -42,22 +42,26 @@ test_that("init = function(chain_id) samples and yields distinct starts", {
 test_that("partial init is reproducible from sampler seed", {
   skip_if(is.null(test_models$normal), "Normal model not compiled")
 
-  data_list <- normal_data()
+  handle <- open_normal_handle()
 
-  # Advance the global RNG between calls so that any reliance on it would
-  # produce different random fills.
-  draws1 <- nutpie_sample(
-    test_models$normal, data = data_list,
-    num_draws = 50, num_chains = 2, seed = 123, refresh = 0,
-    init = list(sigma = 1)
-  )
+  # The property under test: for a partial init, the per-chain random fill of
+  # the missing parameters is driven solely by `seed`, not the global RNG.
+  # Resolve twice with the same seed, advancing the global RNG in between, and
+  # assert the fills are identical. Checking the resolved positions (rather than
+  # a full sampler run) keeps this deterministic across platforms — an
+  # end-to-end draw comparison additionally demands bit-exact floating-point
+  # reproducibility from the Stan model, which some builds don't provide.
+  positions1 <- nutpieR:::resolve_init(
+    init = list(sigma = 1), init_mean = NULL,
+    handle = handle, num_chains = 2, seed = 123
+  )$positions
   invisible(stats::runif(10))
-  draws2 <- nutpie_sample(
-    test_models$normal, data = data_list,
-    num_draws = 50, num_chains = 2, seed = 123, refresh = 0,
-    init = list(sigma = 1)
-  )
-  expect_equal(as.array(draws1), as.array(draws2))
+  positions2 <- nutpieR:::resolve_init(
+    init = list(sigma = 1), init_mean = NULL,
+    handle = handle, num_chains = 2, seed = 123
+  )$positions
+
+  expect_equal(positions1, positions2)
 })
 
 # --- Direct resolve_init unit tests (no sampler) ----------------------------

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -140,6 +140,29 @@ test_that("low_rank_modified_mass_matrix is deprecated but still works", {
   expect_equal(cfg$adapt_options$mass_matrix_update_freq, 20)
 })
 
+test_that("sampler_config records adaptation-specific default warmup", {
+  expect_null(formals(nutpie_sample)$num_warmup)
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  common <- list(
+    model = test_models$bernoulli, data = bernoulli_data(),
+    num_draws = 10, num_chains = 1, seed = 1L, refresh = 0
+  )
+
+  diag_draws <- do.call(nutpie_sample, c(common, list(adaptation = "diag")))
+  low_rank_draws <- do.call(
+    nutpie_sample, c(common, list(adaptation = "low_rank"))
+  )
+
+  expect_equal(
+    jsonlite::fromJSON(attr(diag_draws, "sampler_config"))$num_warmup,
+    400
+  )
+  expect_equal(
+    jsonlite::fromJSON(attr(low_rank_draws, "sampler_config"))$num_warmup,
+    800
+  )
+})
+
 test_that("adaptation = 'low_rank' matches the deprecated flag's behaviour", {
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
   draws_new <- nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
@@ -525,6 +548,9 @@ test_that("adaptation = 'low_rank' produces valid draws", {
   )
   expect_s3_class(draws, "draws_array")
   expect_equal(posterior::niterations(draws), 100)
+  expect_equal(attr(draws, "num_warmup"), 800L)
+  cfg <- jsonlite::fromJSON(attr(draws, "sampler_config"))
+  expect_equal(cfg$num_warmup, 800)
   expect_true("theta" %in% posterior::variables(draws))
 
   # Should reach a similar posterior as standard mass matrix
@@ -538,6 +564,23 @@ test_that("adaptation = 'low_rank' produces valid draws", {
   expect_type(diag$logp, "double")
   expect_true(any(diag$logp != 0))
 })
+
+test_that("generated-quantities failures preserve valid parameter draws", {
+  skip_if(is.null(test_models$gq_failure), "GQ failure model not compiled")
+
+  expect_warning(
+    draws <- nutpie_sample(
+      test_models$gq_failure,
+      num_draws = 20, num_warmup = 20, num_chains = 1,
+      seed = 42, refresh = 0
+    ),
+    "generated quantities"
+  )
+
+  expect_true(all(is.finite(as.numeric(draws[, , "x"]))))
+  expect_true(all(is.nan(as.numeric(draws[, , "invalid_gq"]))))
+})
+
 
 # --- bad-data error path -----------------------------------------------------
 

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -349,16 +349,16 @@ test_that("end summary escalates severe divergence fractions", {
 })
 
 test_that("inferred treedepth matches nuts-rs n_steps scale", {
-  expect_equal(nutpieR:::infer_tree_depth(7L), 2L)
-  expect_equal(nutpieR:::infer_tree_depth(63L), 5L)
-  expect_equal(nutpieR:::infer_tree_depth(255L), 7L)
+  expect_equal(nutpieR:::infer_tree_depth(7L), 3L)
+  expect_equal(nutpieR:::infer_tree_depth(63L), 6L)
+  expect_equal(nutpieR:::infer_tree_depth(255L), 8L)
   expect_equal(nutpieR:::infer_tree_depth(271L), 8L)
 })
 
 test_that("fraction_at_treedepth_cap falls back to n_steps when no depth column", {
   diags <- list(
     chain = rep(1L, 10),
-    n_steps = c(rep(1024, 2), rep(7, 8))  # 2/10 >= 2^10
+    n_steps = c(rep(1023, 2), rep(7, 8))  # 2/10 reach a full depth-10 tree
   )
   expect_equal(nutpieR:::fraction_at_treedepth_cap(diags, 10L), 0.2)
   expect_true(is.na(nutpieR:::fraction_at_treedepth_cap(list(chain = 1L), 10L)))
@@ -645,7 +645,7 @@ test_that("text progress supports the treedepth token", {
     step_size = 0.5, runtime = 1, divergent_draws = integer()
   ))
   out <- testthat::capture_messages(callback(snapshot))
-  expect_match(out, "c1 tdepth: 2", fixed = TRUE)
+  expect_match(out, "c1 tdepth: ~3", fixed = TRUE)
 })
 
 test_that("text grad token switches to per-chain late-warmup baseline", {

--- a/tests/testthat/test-tbb-allocator.R
+++ b/tests/testthat/test-tbb-allocator.R
@@ -3,15 +3,15 @@
 # cover the R-side progress gate, which is pure and injectable.
 
 test_that("gate leaves progress untouched when the allocator is safe", {
-  expect_identical(gate_progress_for_tbb("cli", safe = TRUE), "cli")
-  expect_identical(gate_progress_for_tbb("text", safe = TRUE), "text")
-  expect_identical(gate_progress_for_tbb("none", safe = TRUE), "none")
+  expect_identical(nutpieR:::gate_progress_for_tbb("cli", safe = TRUE), "cli")
+  expect_identical(nutpieR:::gate_progress_for_tbb("text", safe = TRUE), "text")
+  expect_identical(nutpieR:::gate_progress_for_tbb("none", safe = TRUE), "none")
 })
 
 test_that("gate stops sampling when an unsafe allocator is loaded", {
   for (mode in c("none", "cli", "text")) {
     expect_error(
-      gate_progress_for_tbb(mode, safe = FALSE),
+      nutpieR:::gate_progress_for_tbb(mode, safe = FALSE),
       "Restart R"
     )
   }
@@ -54,7 +54,7 @@ test_that("live-progress safety probe is callable and TRUE with no proxy loaded"
   # platforms) no tbbmalloc_proxy is in the process, so the probe is TRUE.
   # If an earlier test in the run compiled a model, the patched proxy is loaded
   # and this is still TRUE — the only FALSE case is a stale unpatched proxy.
-  expect_true(tbb_proxy_live_progress_safe())
+  expect_true(nutpieR:::tbb_proxy_live_progress_safe())
 })
 
 test_that("bundled TBB proxy header still matches the verbatim splice (#36)", {
@@ -64,7 +64,7 @@ test_that("bundled TBB proxy header still matches the verbatim splice (#36)", {
   # either the stock function text or nutpieR's marker, so such a bump fails
   # loudly in CI/dev.
   skip_on_os(c("windows", "linux", "solaris"))
-  strings <- tbb_patch_strings()
+  strings <- nutpieR:::tbb_patch_strings()
   skip_if(length(strings) < 2L, "TBB patch strings unavailable (non-macOS build).")
   stock <- strings[[1L]]
   marker <- strings[[2L]]

--- a/tests/testthat/test-tbb-allocator.R
+++ b/tests/testthat/test-tbb-allocator.R
@@ -8,28 +8,45 @@ test_that("gate leaves progress untouched when the allocator is safe", {
   expect_identical(gate_progress_for_tbb("none", safe = TRUE), "none")
 })
 
-test_that("gate warns for progress = 'none' too but leaves the mode alone", {
-  # The session is at risk for every allocation, not just live progress, so an
-  # unsafe allocator warns even in "none" mode — but the mode stays "none".
-  withr::local_options(nutpieR.tbb_gate_warned = NULL)
-  expect_warning(
-    expect_identical(gate_progress_for_tbb("none", safe = FALSE), "none"),
-    "tbbmalloc_proxy"
+test_that("gate stops sampling when an unsafe allocator is loaded", {
+  for (mode in c("none", "cli", "text")) {
+    expect_error(
+      gate_progress_for_tbb(mode, safe = FALSE),
+      "Restart R"
+    )
+  }
+})
+
+test_that("sampling checks allocator safety before opening a model", {
+  testthat::local_mocked_bindings(
+    tbb_proxy_live_progress_safe = function() FALSE,
+    bs_open = function(...) stop("model was opened"),
+    .package = "nutpieR"
+  )
+  expect_error(
+    nutpie_sample("not-used", num_draws = 1, num_chains = 1, refresh = 0),
+    "Restart R"
   )
 })
 
-test_that("gate downgrades live progress and warns once when unsafe", {
-  withr::local_options(nutpieR.tbb_gate_warned = NULL)
-
-  expect_warning(
-    expect_identical(gate_progress_for_tbb("cli", safe = FALSE), "none"),
-    "tbbmalloc_proxy"
+test_that("sampling rechecks allocator safety immediately after opening", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  calls <- 0L
+  testthat::local_mocked_bindings(
+    tbb_proxy_live_progress_safe = function() {
+      calls <<- calls + 1L
+      calls == 1L
+    },
+    .package = "nutpieR"
   )
-  # Second call in the same session downgrades silently (warned-once flag set).
-  expect_no_warning(
-    expect_identical(gate_progress_for_tbb("text", safe = FALSE), "none")
+  expect_error(
+    nutpie_sample(
+      test_models$bernoulli, data = bernoulli_data(),
+      num_draws = 1, num_chains = 1, refresh = 0
+    ),
+    "Restart R"
   )
-  expect_true(getOption("nutpieR.tbb_gate_warned"))
+  expect_equal(calls, 2L)
 })
 
 test_that("live-progress safety probe is callable and TRUE with no proxy loaded", {

--- a/tests/testthat/test_models/gq_failure.stan
+++ b/tests/testthat/test_models/gq_failure.stan
@@ -1,0 +1,9 @@
+parameters {
+  real x;
+}
+model {
+  x ~ normal(0, 1);
+}
+generated quantities {
+  real<lower=0> invalid_gq = -1;
+}


### PR DESCRIPTION
## TL;DR
A small quality-of-life release: minor correctness fixes, safer compilation/sampling behavior, and clearer diagnostics.

## Summary
- **Safer compilation and sampling:** serialize concurrent cache misses for the same Stan model, validate cache-pruning inputs, and stop macOS sampling before an already-loaded unsafe TBB allocator can affect model setup or result assembly. Not super common or likely, but easy to structurally prevent.
- **More consistent defaults:** use `num_warmup = NULL`, matching python nutpie’s unspecified-warmup API idea; this resolves to 400 warmup draws for diagonal adaptation and 800 for low-rank adaptation, with the effective value retained in `sampler_config`.
- **Clearer diagnostics and failure handling:** correct the tree-depth accounting mistake I introduced: a complete depth-`d` tree has `2^d - 1` leapfrog steps, so the old live display/fallback could report complete trees one level too low. Live depth is now marked as an estimate; this also clarifies filtered R-hat/ESS summaries and preserves valid parameter values when transformed-output expansion fails.

## Validation
- usual build checks + tests
- a bit more tire kicking on mac for the cache robustness stuff
