### PR TITLE
Preserve data precision and reduce draws copying

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.8.5
+Version: 1.8.6
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # nutpieR 1.8.6
 
-* List-form model data and reported sampler configuration now preserve maximum
-  numeric precision during JSON serialization.
+* List-form model data now preserve maximum numeric precision during JSON
+  serialization. Previously, values around 1 could be rounded by up to `5e-5`,
+  mainly affecting tasks where the fifth decimal place in the data's units is
+  scientifically meaningful. Reported sampler configuration retains the same
+  precision.
 * Reduced result-assembly time and peak memory by avoiding a redundant
   full-size draws copy.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# nutpieR 1.8.6
+
+* List-form model data and reported sampler configuration now preserve maximum
+  numeric precision during JSON serialization.
+* Reduced result-assembly time and peak memory by avoiding a redundant
+  full-size draws copy.
+
 # nutpieR 1.8.5
 
 * Safer compilation and sampling: concurrent cache misses now use per-entry

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # nutpieR 1.8.6
 
 * List-form model data now preserve maximum numeric precision during JSON
-  serialization. Previously, values around 1 could be rounded by up to `5e-5`,
-  mainly affecting tasks where the fifth decimal place in the data's units is
-  scientifically meaningful. Reported sampler configuration retains the same
-  precision.
+  serialization. Previously, the `jsonlite::toJSON()` default rounded ordinary
+  fixed-decimal values to four decimal places—an error of at most `5e-5` in the
+  data's units—mainly affecting tasks where precision at that scale is
+  scientifically meaningful. JSON strings and files were unaffected. Reported
+  sampler configuration now retains maximum numeric precision too.
 * Reduced result-assembly time and peak memory by avoiding a redundant
   full-size draws copy.
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -23,7 +23,7 @@ rename_sampler_config <- function(json_str) {
       cfg$num_warmup <- cfg$num_tune
       cfg$num_tune <- NULL
     }
-    jsonlite::toJSON(cfg, auto_unbox = TRUE)
+    jsonlite::toJSON(cfg, auto_unbox = TRUE, digits = NA)
   }, error = function(e) json_str)
 }
 

--- a/R/results.R
+++ b/R/results.R
@@ -1,13 +1,9 @@
 #' Convert a flat draws matrix to posterior::draws_array
 #'
-#' The flat matrix Rust hands us is already laid out (column-major) such that
-#' the (n_draws, n_chains, n_params) shape needs no permutation. R may make one
-#' copy when the attributes are changed because the matrix is still referenced
-#' by the raw result list. Assign the standard posterior classes directly once
-#' the dimensions are valid: sending this otherwise-ready array through
-#' `posterior::as_draws_array()` dispatches through its default method and makes
-#' a second full copy. For a 10k draws × 4 chains × 1k params result, each
-#' avoidable copy is about 305 MiB.
+#' The flat matrix is already in `(draw, chain, parameter)` order, so reshaping
+#' needs no permutation. Assigning the standard posterior classes directly
+#' avoids the full-buffer copy made by `posterior::as_draws_array()`'s default
+#' method — about 305 MiB for 10k draws × 4 chains × 1k parameters.
 #'
 #' @param flat_matrix Matrix with (n_draws * n_chains) rows and n_params
 #'   columns. Rows are ordered by chain (chain 1 rows first, then chain 2, etc).

--- a/R/results.R
+++ b/R/results.R
@@ -1,11 +1,13 @@
 #' Convert a flat draws matrix to posterior::draws_array
 #'
 #' The flat matrix Rust hands us is already laid out (column-major) such that
-#' the (n_draws, n_chains, n_params) shape is just a different `dim` attribute
-#' on the same buffer — no permutation or copy needed. Reassigning `dim`
-#' in-place avoids the full memcpy that `array(flat_matrix, dim = ...)` would
-#' do; on a 10k draws × 4 chains × 1k params (~305 MB) result this is the
-#' difference between ~500 ms and ~2 ms of post-sample R-side work.
+#' the (n_draws, n_chains, n_params) shape needs no permutation. R may make one
+#' copy when the attributes are changed because the matrix is still referenced
+#' by the raw result list. Assign the standard posterior classes directly once
+#' the dimensions are valid: sending this otherwise-ready array through
+#' `posterior::as_draws_array()` dispatches through its default method and makes
+#' a second full copy. For a 10k draws × 4 chains × 1k params result, each
+#' avoidable copy is about 305 MiB.
 #'
 #' @param flat_matrix Matrix with (n_draws * n_chains) rows and n_params
 #'   columns. Rows are ordered by chain (chain 1 rows first, then chain 2, etc).
@@ -22,7 +24,8 @@ matrix_to_draws_array <- function(flat_matrix, n_draws, n_chains) {
     chain = seq_len(n_chains),
     variable = param_names
   )
-  posterior::as_draws_array(flat_matrix)
+  class(flat_matrix) <- c("draws_array", "draws", "array")
+  flat_matrix
 }
 
 #' Block-level prefixes from a vector of bridgestan dot-indexed names

--- a/R/sample.R
+++ b/R/sample.R
@@ -617,7 +617,7 @@ resolve_data <- function(data) {
       stop("Package 'jsonlite' is required to convert list data to JSON.",
            call. = FALSE)
     }
-    return(jsonlite::toJSON(data, auto_unbox = TRUE))
+    return(jsonlite::toJSON(data, auto_unbox = TRUE, digits = NA))
   }
   stop("`data` must be NULL, a JSON string, a .json file path, or a named list.",
        call. = FALSE)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ defaults: 400 warmup draws for diagonal adaptation and 800 for low-rank.
 
 nutpieR compiles Stan models via the BridgeStan Rust crate and samples using the nuts-rs NUTS sampler. During sampling, Rust calls the compiled Stan shared library directly through BridgeStan's C ABI -- R is not involved in the sampling loop. Each chain runs on its own thread via rayon.
 
-Results are transferred from Rust to R via Apache Arrow with a single copy into R-allocated memory (no extra intermediate buffer), and returned as a `posterior::draws_array`.
+Results are transferred from Rust to R via Apache Arrow and returned as a `posterior::draws_array`.
 
 Compiled artifacts are cached, matching cmdstanr's convention -- repeat calls return in <1s. See `?nutpie_compile_model` for cache controls and `?nutpie_clear_cache` to invalidate.
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -942,12 +942,9 @@ fn sample_stan(
             &kept_param_names,
         )?;
 
-        // Defensive boundary filter for the two opt-in, `ndim_unc`-wide
-        // diagnostics. The pinned nuts-rs honours both storage flags, so these
-        // columns are normally all-null and the schema-driven filter below
-        // would drop them anyway. Keep the explicit suppression so the R API
-        // continues to honour its defaults if an upstream schema or settings
-        // regression ever populates them unexpectedly.
+        // The pinned nuts-rs honours these opt-in storage flags and normally
+        // leaves the columns null. Suppress them explicitly so an upstream
+        // regression cannot change the documented R defaults.
         let mut drop_cols: Vec<&str> = Vec::new();
         if !store_unconstrained {
             drop_cols.push("unconstrained_draw");

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -942,15 +942,12 @@ fn sample_stan(
             &kept_param_names,
         )?;
 
-        // Diagnostic columns to suppress at the R boundary. nuts-rs 0.17.4
-        // populates `unconstrained_draw` and `gradient` unconditionally
-        // regardless of `store_unconstrained` / `store_gradient` (the flags
-        // exist but are not read in `chain.rs::extract_stats`). To match the
-        // documented R-side semantics — and to avoid surfacing one
-        // `ndim_unc`-wide list-of-vectors per draw by default — drop those
-        // columns here unless the user opts in. When nuts-rs starts honouring
-        // the flags, the columns will already be all-null and our existing
-        // `any_non_null` filter will drop them.
+        // Defensive boundary filter for the two opt-in, `ndim_unc`-wide
+        // diagnostics. The pinned nuts-rs honours both storage flags, so these
+        // columns are normally all-null and the schema-driven filter below
+        // would drop them anyway. Keep the explicit suppression so the R API
+        // continues to honour its defaults if an upstream schema or settings
+        // regression ever populates them unexpectedly.
         let mut drop_cols: Vec<&str> = Vec::new();
         if !store_unconstrained {
             drop_cols.push("unconstrained_draw");

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -19,11 +19,13 @@ test_that("resolve_data handles JSON string", {
   expect_equal(nutpieR:::resolve_data(json), json)
 })
 
-test_that("resolve_data handles list", {
-  result <- nutpieR:::resolve_data(list(N = 10, y = c(0, 1)))
+test_that("resolve_data handles list without rounding numeric data", {
+  x <- c(0.123456789012345, 0.999999, 1.000001, -0.000049999)
+  result <- nutpieR:::resolve_data(list(N = 10, y = c(0, 1), x = x))
   parsed <- jsonlite::fromJSON(result)
   expect_equal(parsed$N, 10)
   expect_equal(parsed$y, c(0, 1))
+  expect_equal(parsed$x, x)
 })
 
 test_that("resolve_data handles .json file", {
@@ -594,6 +596,16 @@ test_that("sampling with bad data gives R error, not crash", {
 })
 
 # --- sampler_config attribute ------------------------------------------------
+
+test_that("sampler_config renaming preserves numeric precision", {
+  raw <- paste0(
+    '{"num_tune":400,"target_accept":',
+    '0.8123456789012345}'
+  )
+  cfg <- jsonlite::fromJSON(nutpieR:::rename_sampler_config(raw))
+  expect_equal(cfg$num_warmup, 400)
+  expect_equal(cfg$target_accept, 0.8123456789012345)
+})
 
 test_that("sampler_config is parseable JSON capturing effective settings", {
   skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")

--- a/tests/testthat/test-results.R
+++ b/tests/testthat/test-results.R
@@ -1,0 +1,23 @@
+test_that("matrix_to_draws_array creates a valid posterior draws array", {
+  flat <- matrix(
+    seq_len(12),
+    nrow = 4,
+    dimnames = list(NULL, c("alpha", "beta.1", "beta.2"))
+  )
+
+  draws <- nutpieR:::matrix_to_draws_array(flat, n_draws = 2L, n_chains = 2L)
+
+  expect_identical(class(draws), c("draws_array", "draws", "array"))
+  expect_identical(dim(draws), c(2L, 2L, 3L))
+  expect_identical(
+    dimnames(draws),
+    list(
+      iteration = c("1", "2"),
+      chain = c("1", "2"),
+      variable = c("alpha", "beta[1]", "beta[2]")
+    )
+  )
+  expect_equal(as.numeric(draws[, 1, "alpha"]), c(1, 2))
+  expect_equal(as.numeric(draws[, 2, "alpha"]), c(3, 4))
+  expect_no_error(posterior::summarise_draws(draws))
+})


### PR DESCRIPTION
## TL;DR
small many decimal precision and result-assembly memory improvements: preserve maximum numeric precision for list-form model data and avoid one redundant full-size draws copy in R.

## Summary
- Serialize list-form `data` with `jsonlite::toJSON(..., digits = NA)` instead of its four-decimal default. This is expected to be negligible for the vast majority models, but avoids unnecessary input rounding in particularly precision-sensitive models.
- Preserve the same precision when renaming `num_tune` to `num_warmup` in the reported `sampler_config`; this changes metadata only, not the settings used by nuts-rs.
- Assign the already-valid posterior array classes directly after reshaping the Rust result. Calling `posterior::as_draws_array()` through its default method made an additional full-buffer copy.
- Correct stale comments/docs about result transfer and the pinned nuts-rs diagnostic storage flags.

## Max Memory Impact
For a 10,000 draw × 4 chain × 1,000 parameter result, the removed copy is about 305 MiB. A local 61.1 MiB conversion microbenchmark improved from 0.014s to 0.001s with identical unclassed output. This just affects result finalization and peak memory.

## Validation
- usual tests
- tire kicking of copying improvement to make sure gains are worth it
- testing at what scale the `toJSON()` issue bites, which turned out to be pretty small
