### PR TITLE
Support Windows arm64 builds

### DIFF
--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -1,4 +1,4 @@
-TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+TARGET = @WINDOWS_TARGET@
 
 # Ensure cargo is on PATH (Windows R subprocess may not inherit it)
 CARGO_BIN = $(HOME)/.cargo/bin

--- a/tools/config.R
+++ b/tools/config.R
@@ -72,6 +72,15 @@ cfg <- if (is_debug) "debug" else "release"
 
 # read in the Makevars.in file checking
 is_windows <- .Platform[["OS.type"]] == "windows"
+.windows_target <- if (grepl("aarch", R.version$platform)) {
+  "aarch64-pc-windows-gnullvm"
+} else if (grepl("clang", Sys.getenv("R_COMPILED_BY"))) {
+  "x86_64-pc-windows-gnullvm"
+} else if (grepl("i386", R.version$platform)) {
+  "i686-pc-windows-gnu"
+} else {
+  "x86_64-pc-windows-gnu"
+}
 
 # if windows we replace in the Makevars.win.in
 mv_fp <- ifelse(
@@ -99,6 +108,7 @@ mv_txt <- readLines(mv_fp)
 # replace placeholder values
 new_txt <- gsub("@CRAN_FLAGS@", .cran_flags, mv_txt) |>
   gsub("@PROFILE@", .profile, x = _) |>
+  gsub("@WINDOWS_TARGET@", .windows_target, x = _) |>
   gsub("@CLEAN_TARGET@", .clean_targets, x = _) |>
   gsub("@LIBDIR@", .libdir, x = _) |>
   gsub("@TARGET@", .target, x = _) |>


### PR DESCRIPTION
## TL;DR

- generate the Rust Windows target from R's platform/toolchain metadata
- use `aarch64-pc-windows-gnullvm` for native Windows arm64 builds
- preserve `x86_64-pc-windows-gnu` for the existing Rtools GCC builds

## Context

R-universe added Windows arm64 jobs for compiled packages in late July. On arm64, R leaves the legacy `WIN` make variable empty, so the old template generated `--target=-pc-windows-gnu`. This ports the Windows target mapping from [rextendr #532](https://github.com/extendr/rextendr/pull/532).

## Validation

- `tools/config.R` parses successfully
- target generation checked for Windows arm64, x86_64 GCC, x86_64 LLVM, and i386
- other usual tests/checks
