### PR TITLE
Fix include caching and sampler boundary handling

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,7 @@
 ^LICENSE\.md$
 ^\.github$
 ^CLAUDE\.md$
+^MAINTENANCE-HANDOFF\.md$
 ^\.claude$
 ^ai_context$
 ^\.vscode$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutpieR
 Title: R Bindings for the Nutpie NUTS Sampler
-Version: 1.8.6
+Version: 1.8.7
 Authors@R:
     person("Andy", "Timm", role = c("aut", "cre"),
            email = "timmandrew1@gmail.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# nutpieR (development version)
+
+* Fixed stale cache hits after editing external Stan `#include` files, for
+  file and inline models. Nested includes now follow stanc's search paths.
+* Documented `I(3)` and explicit arrays/matrices for singleton data.
+* `num_warmup = 0` now gives a clear error instead of a sampler panic.
+
 # nutpieR 1.8.6
 
 * List-form model data now preserve maximum numeric precision during JSON

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# nutpieR (development version)
+# nutpieR 1.8.7
 
 * Fixed stale cache hits after editing external Stan `#include` files, for
   file and inline models. Nested includes now follow stanc's search paths.

--- a/R/cache.R
+++ b/R/cache.R
@@ -26,89 +26,15 @@ CACHE_MIN_AGE_DAYS <- 14L
 
 # --- Source bundle construction --------------------------------------------
 
-# Returns paths referenced by `#include` directives in stan_file (direct
-# children only; use all_deps() for the transitive set). Handles bare,
-# quoted, and angle-bracket forms with any amount of whitespace after
-# `#include`. Stan `//` and `/* */` comments are stripped first so a
-# commented-out directive doesn't get tracked as a real dependency, and
-# the directive itself must be at the start of a (whitespace-only) line.
-included_files <- function(stan_file) {
-  text <- paste(readLines(stan_file, warn = FALSE), collapse = "\n")
-  text <- gsub("(?s)/\\*.*?\\*/", "", text, perl = TRUE)
-  text <- gsub("//[^\n]*", "", text, perl = TRUE)
-  lines <- strsplit(text, "\n", fixed = TRUE)[[1L]]
-  matches <- regmatches(lines, regexpr("^\\s*#include\\s+\\S+", lines))
-  if (!length(matches)) return(character())
-  raw <- sub("^\\s*#include\\s+", "", matches)
-  file.path(dirname(stan_file), gsub('["<>]', "", raw))
-}
+# Cache format version.  Bump this whenever the interpretation of a source
+# bundle changes: otherwise a library built from the old staging scheme could
+# be mistaken for one built from the new scheme.
+CACHE_SCHEMA_VERSION <- 2L
 
 canonical_path <- function(path) {
   normalizePath(path, mustWork = FALSE, winslash = "/")
 }
 
-# Walks #include directives transitively. Visited set is keyed on the
-# canonical form so paths like `../foo.stan` and `foo.stan` resolved from
-# sibling dirs don't double-count. Missing dependencies stay in the
-# result -- the source bundle treats them as empty content so a deleted
-# include still busts the hash.
-all_deps <- function(stan_file, visited = character()) {
-  key <- canonical_path(stan_file)
-  if (key %in% visited) return(visited)
-  visited <- c(visited, key)
-  if (!file.exists(stan_file)) return(visited)
-  for (inc in included_files(stan_file)) {
-    visited <- all_deps(inc, visited)
-  }
-  visited
-}
-
-# Lowest common ancestor of a set of canonical paths, at path-component
-# granularity. Used to figure out where to root the staged copy so each
-# dep's relative position is preserved -- so `#include "../foo.stan"`
-# still resolves under the cache dir.
-common_root <- function(paths) {
-  if (length(paths) == 0L) return(NULL)
-  if (length(paths) == 1L) return(dirname(paths[1L]))
-  parts <- strsplit(paths, "/", fixed = TRUE)
-  min_len <- min(lengths(parts))
-  if (min_len == 0L) return(NULL)
-  shared <- character()
-  for (i in seq_len(min_len)) {
-    seg <- vapply(parts, function(p) p[[i]], character(1L))
-    if (length(unique(seg)) != 1L) break
-    shared <- c(shared, seg[[1L]])
-  }
-  if (length(shared) == 0L) return(NULL)
-  root <- paste(shared, collapse = "/")
-  if (!nzchar(root)) "/" else root
-}
-
-# Returns path with `root` stripped (root assumed to be a prefix). Both
-# inputs must be canonical. Strips the trailing slash on root before
-# comparing so root == "/foo" matches path "/foo/bar.stan".
-relative_to <- function(path, root) {
-  if (identical(root, "/")) {
-    sub("^/", "", path)
-  } else {
-    prefix <- paste0(root, "/")
-    if (!startsWith(path, prefix)) {
-      stop("path ", path, " is not under root ", root, call. = FALSE)
-    }
-    substr(path, nchar(prefix) + 1L, nchar(path))
-  }
-}
-
-# Returns the file's raw byte content, or NULL if the path doesn't
-# exist. Raw bytes (not readLines() text) so the cache key is sensitive
-# to trailing-newline differences, line-ending differences, and any
-# encoding round-trip oddities -- a content cache should never falsely
-# claim two byte-distinct files match. The NULL marker lets the bundle
-# differentiate "present-and-empty" from "missing" in the hash (so
-# deleting a `#include` busts the cache) while letting stage_bundle()
-# skip writing the file so stanc surfaces a real "Could not find
-# include file" error instead of silently treating the include as an
-# empty no-op.
 read_dep <- function(path) {
   if (file.exists(path)) {
     readBin(path, what = raw(), n = file.info(path)$size)
@@ -117,57 +43,231 @@ read_dep <- function(path) {
   }
 }
 
-# Build a source bundle = ordered list of (rel_path, content) pairs plus
-# the rel_path of the main file to compile. For inline code there's a
-# single synthetic file at `model.stan`; for file input we stage the
-# transitive include set under the lowest common ancestor so relative
-# `#include`s still resolve at compile time. `display_source` records
-# what to show users (their original path, or NA for inline) since the
-# main staged path under the cache dir isn't meaningful to them.
-# `content` is always a raw vector (matching file_bundle), so the hash
-# is computed over the same byte representation as the staged file.
-inline_bundle <- function(code) {
+# Do not parse Stan includes in R.  stanc owns that grammar and, importantly,
+# its search rule is based on the main source root rather than the directory of
+# the file containing a nested include.  This cheap gate merely preserves the
+# ordinary no-include fast path; a false positive only runs stanc's resolver.
+has_possible_include <- function(content) {
+  # stanc accepts directives after other tokens on a line (for example,
+  # `functions { #include f.stan }`).  This deliberately broad token search
+  # has false positives in comments but no known syntax-shaped false negatives.
+  grepl("#include", rawToChar(content), fixed = TRUE)
+}
+
+source_bundle <- function(content, main = INLINE_STAN, display_source = NA_character_) {
   list(
-    files = list(list(
-      rel_path = INLINE_STAN,
-      content  = charToRaw(enc2utf8(code))
-    )),
-    main = INLINE_STAN,
-    display_source = NA_character_
+    files = list(list(rel_path = main, content = content)),
+    main = main,
+    display_source = display_source,
+    dependencies = list()
   )
 }
 
+inline_bundle <- function(code) {
+  source_bundle(charToRaw(enc2utf8(code)))
+}
+
 file_bundle <- function(stan_file) {
-  deps <- all_deps(stan_file)
-  root <- common_root(deps)
-  if (is.null(root)) {
-    stop(
-      "Could not find a common root for `#include` dependencies of ",
-      stan_file, ". Use absolute paths under a shared directory.",
-      call. = FALSE
-    )
+  stan_file <- canonical_path(stan_file)
+  source_bundle(
+    read_dep(stan_file),
+    main = basename(stan_file),
+    display_source = stan_file
+  )
+}
+
+stanc_system <- function(stanc, args) {
+  # system2 invokes a shell on some R platforms.  Quote every complete
+  # argument, not just paths, so an include directory with spaces remains one
+  # --include-paths value.  Arguments are still passed in their supplied order.
+  # Keep stderr out of stdout: --info and --auto-format stdout is structured
+  # JSON/source and compiler warnings must never become cached Stan text.
+  err_file <- tempfile("nutpieR-stanc-stderr-")
+  on.exit(unlink(err_file, force = TRUE), add = TRUE)
+  output <- suppressWarnings(system2(
+    stanc,
+    args = vapply(args, shQuote, character(1L)),
+    stdout = TRUE,
+    stderr = err_file
+  ))
+  diagnostics <- if (file.exists(err_file)) readLines(err_file, warn = FALSE) else character()
+  status <- attr(output, "status")
+  if (!is.null(status) && status != 0L) {
+    stop(paste(c(output, diagnostics), collapse = "\n"), call. = FALSE)
   }
-  files <- lapply(deps, function(p) {
-    list(rel_path = relative_to(p, root), content = read_dep(p))
+  output
+}
+
+# Run a short synchronous stanc subprocess in BridgeStan's working directory
+# without making the test-only `withr` package a runtime dependency.
+with_stanc_workdir <- function(path, expr) {
+  old <- getwd()
+  on.exit(setwd(old), add = TRUE)
+  setwd(path)
+  force(expr)
+}
+
+# BridgeStan's compile_model prepends --include-paths=<main source directory>
+# before the supplied flags.  Repeat that exact ordered prefix for stanc's
+# resolver.  stanc accumulates repeated include-paths flags, so do not combine,
+# sort, or de-duplicate user flags.
+stanc_args_for_source <- function(stan_file, stanc_args) {
+  c(
+    paste0("--include-paths=", dirname(normalizePath(stan_file))),
+    as.character(stanc_args)
+  )
+}
+
+# A few output-mode switches are not normal compile overrides.  Combining one
+# with --info/--auto-format changes stanc's output contract, so do not infer a
+# cache key from it.  The caller takes the conservative uncached path instead.
+stanc_make_override_present <- function(stanc = NULL) {
+  # MAKEFLAGS can inject variable assignments or select another makefile, and
+  # MAKEFILES loads make fragments before BridgeStan's Makefile.  Either can
+  # select a compiler with include rules different from bundled stanc.
+  if (nzchar(Sys.getenv("MAKEFLAGS", unset = "")) ||
+      nzchar(Sys.getenv("MAKEFILES", unset = "")) ||
+      nzchar(Sys.getenv("STANC", unset = "")) ||
+      nzchar(Sys.getenv("STANCFLAGS", unset = ""))) {
+    return(TRUE)
+  }
+  if (is.null(stanc)) {
+    stanc <- tryCatch(bridgestan_stanc_path(), error = function(e) NULL)
+  }
+  if (is.null(stanc)) return(TRUE)
+  # A non-empty user make/local can change stanc or its inputs by arbitrary
+  # make logic.  It is deliberately treated as untrackable rather than trying
+  # to parse a makefile in R.
+  local <- file.path(dirname(dirname(stanc)), "make", "local")
+  file.exists(local) && isTRUE(file.info(local)$size > 0L)
+}
+stanc_tracking_supported <- function(stanc_args, compile_args = character()) {
+  args <- as.character(stanc_args)
+  output_mode <- any(grepl(
+    "^(--(?:auto-format|print-canonical|print-cpp|info)(?:=|$)|--output(?:=|$)|-o(?:$|.))",
+    args,
+    perl = TRUE
+  ))
+  # BridgeStan joins STANCFLAGS into make's shell command.  Quoted or
+  # whitespace-containing elements can therefore mean something different
+  # from an argv-based system2 invocation; use the direct uncached compiler
+  # route instead of deriving a possibly different dependency set.
+  # Only accept arguments whose characters have identical plain-word meaning
+  # in BridgeStan's make-shell STANCFLAGS string and in system2 argv.  Shell
+  # expansion/quoting characters ($, backticks, backslashes, globs, pipes,
+  # redirects, etc.) take the direct uncached route.
+  shell_sensitive <- any(!grepl("^[[:alnum:]_./,:=+@%-]+$", args))
+  make_overrides <- any(grepl(
+    paste0(
+      "^(?:STANC|STANCFLAGS|MAKEFILES|MAKEFLAGS)(?::|\\+|\\?)?=",
+      "|^-f|^--(?:file|makefile)(?:=|$)|^--eval(?:=|$)|^-E(?:.|$)"
+    ),
+    as.character(compile_args), perl = TRUE
+  )) || stanc_make_override_present()
+  !(output_mode || shell_sensitive || make_overrides)
+}
+
+# Ask the bundled stanc itself for both the resolved dependency list and the
+# canonical source with #includes expanded.  The expansion makes the staged
+# compilation independent of the cache directory's layout, including nested
+# includes found through the main source root or ordered external search paths.
+# It intentionally means compiler diagnostics for include models refer to the
+# staged expanded source rather than an original include line; stanc exposes no
+# source-map format for preserving those locations.
+resolve_included_source <- function(stan_file, stanc_args,
+                                    compile_args = character()) {
+  if (!stanc_tracking_supported(stanc_args, compile_args)) {
+    return(NULL)
+  }
+  stanc <- bridgestan_stanc_path()
+  common <- stanc_args_for_source(stan_file, stanc_args)
+  # BridgeStan runs make (and therefore stanc) from its downloaded source
+  # directory.  Use the same cwd as well as the same argument order.
+  stanc_run <- function(args) {
+    with_stanc_workdir(dirname(dirname(stanc)), stanc_system(stanc, args))
+  }
+  info <- tryCatch(
+    stanc_run(c("--info", "--color=never", common, stan_file)),
+    error = identity
+  )
+  if (inherits(info, "error")) {
+    # A missing include is a real compiler error, not an excuse to reuse an
+    # old entry.  Returning the error lets callers see stanc's own diagnostic.
+    stop(conditionMessage(info), call. = FALSE)
+  }
+  parsed <- tryCatch(
+    jsonlite::fromJSON(paste(info, collapse = "\n"), simplifyVector = FALSE),
+    error = identity
+  )
+  if (inherits(parsed, "error") || is.null(parsed$included_files)) {
+    return(NULL)
+  }
+  expanded <- tryCatch(
+    stanc_run(c(
+      "--auto-format", "--canonicalize=includes", "--color=never",
+      common, stan_file
+    )),
+    error = identity
+  )
+  if (inherits(expanded, "error")) return(NULL)
+
+  included <- vapply(parsed$included_files, canonical_path, character(1L))
+  # Keep the bytes separately from the expanded source.  This deliberately
+  # invalidates on every dependency-byte edit, even edits stripped by the
+  # formatter, and records a deleted dependency as NULL rather than a cache hit.
+  dependencies <- lapply(sort(unique(included)), function(path) {
+    list(path = path, content = read_dep(path))
   })
-  main_rel <- relative_to(canonical_path(stan_file), root)
-  list(files = files, main = main_rel,
-       display_source = canonical_path(stan_file))
+  list(
+    content = charToRaw(enc2utf8(paste(expanded, collapse = "\n"))),
+    dependencies = dependencies
+  )
+}
+
+# Build a bundle for the requested source.  The normal path does no subprocess
+# work.  Include-bearing sources are resolved and expanded by stanc before they
+# are staged, exactly avoiding a second, hand-written approximation of stanc's
+# include rules.
+bundle_for_compile <- function(stan_file = NULL, code = NULL, stanc_args = character(),
+                               compile_args = character()) {
+  raw <- if (is.null(stan_file)) inline_bundle(code) else file_bundle(stan_file)
+  if (!has_possible_include(raw$files[[1L]]$content)) return(raw)
+
+  analysis_dir <- NULL
+  analysis_file <- stan_file
+  if (is.null(analysis_file)) {
+    analysis_dir <- tempfile("nutpieR-include-analysis-")
+    dir.create(analysis_dir, recursive = TRUE)
+    analysis_file <- file.path(analysis_dir, INLINE_STAN)
+    writeBin(raw$files[[1L]]$content, analysis_file)
+    on.exit(unlink(analysis_dir, recursive = TRUE, force = TRUE), add = TRUE)
+  }
+  resolved <- resolve_included_source(analysis_file, stanc_args, compile_args)
+  if (is.null(resolved)) {
+    attr(raw, "untracked_includes") <- TRUE
+    return(raw)
+  }
+  # Retain the original main bytes as well.  The expanded source is what is
+  # compiled, while this keeps the cache's byte-sensitive invalidation promise
+  # for comments/formatting in the main file and avoids an inline temporary
+  # analysis path becoming part of the key.
+  main_dependency <- list(
+    path = if (is.null(stan_file)) INLINE_STAN else canonical_path(stan_file),
+    content = raw$files[[1L]]$content
+  )
+  raw$files[[1L]]$content <- resolved$content
+  raw$dependencies <- c(list(main_dependency), resolved$dependencies)
+  raw
 }
 
 # --- Hash key --------------------------------------------------------------
 
-# Argument order is preserved (no sort): for override-style flags like
-# `--name=foo --name=bar`, semantics are order-sensitive and we don't
-# want the cache to silently coalesce them.
 cache_key <- function(bundle, bs_version, stanc_args, compile_args) {
-  # Sort files by rel_path so two equivalent bundles (e.g. different
-  # walk orders of the same include tree) hash to the same key.
-  # display_source is *not* hashed: two users compiling the same
-  # source under different paths should share a cache slot.
   sorted <- bundle$files[order(vapply(bundle$files, `[[`, character(1L), "rel_path"))]
   payload <- list(
+    schema = CACHE_SCHEMA_VERSION,
     files = sorted,
+    dependencies = bundle$dependencies,
     main = bundle$main,
     bs_version = bs_version,
     stanc_args = as.character(stanc_args),
@@ -176,9 +276,6 @@ cache_key <- function(bundle, bs_version, stanc_args, compile_args) {
   substr(digest::digest(payload, algo = "sha256"), 1L, 16L)
 }
 
-# Kept as a thin shim so existing internal tests against
-# `inline_cache_key(code, ...)` (string-flavoured) still pass. The full
-# bundle hash is accessed via `cache_key()`.
 inline_cache_key <- function(content, bs_version, stanc_args, compile_args) {
   cache_key(inline_bundle(content), bs_version, stanc_args, compile_args)
 }
@@ -455,6 +552,53 @@ compile_no_cache <- function(bundle, stanc_args, compile_args, verbose) {
   )
 }
 
+# Compile an include-bearing source only when compiler tracking is unavailable.
+# The fresh directory guarantees a new library path.  For file input, make the
+# original main-source root the next include root after BridgeStan's empty
+# staging root, preserving its normal parent-before-user search precedence as
+# closely as possible without pretending that an unsafe cache key is valid.
+compile_no_cache_untracked <- function(bundle, source_path, stanc_args,
+                                       compile_args, verbose) {
+  if (is.null(source_path)) {
+    return(compile_no_cache(bundle, stanc_args, compile_args, verbose))
+  }
+  source_dir <- dirname(source_path)
+  if (grepl(" ", source_path, fixed = TRUE) || file.access(source_dir, 2L) != 0L) {
+    stop(
+      "Cannot safely use an untrackable compiler/make override for this ",
+      "include model: its source directory must be writable and have no spaces. ",
+      "Remove the override or use a source path meeting these requirements.",
+      call. = FALSE
+    )
+  }
+
+  # A custom stanc/make override can have include semantics that the bundled
+  # resolver cannot prove.  Compile the original file in its original parent
+  # directory so BridgeStan prepends exactly that source root.  Serialise this
+  # source-adjacent build across R processes: both stanc's .hpp and BridgeStan's
+  # .so name are fixed by the source basename.  Copy only the result to a fresh
+  # tempdir before returning it, so callers never receive a reusable dlopen path.
+  # This rare conservative route may leave BridgeStan's normal .hpp/.so build
+  # by-products beside the source, just like a direct BridgeStan compilation.
+  lock_entry <- file.path(
+    source_dir,
+    paste0(".nutpieR-untracked-", digest::digest(canonical_path(source_path), algo = "sha256"))
+  )
+  with_cache_entry_lock(lock_entry, {
+    built <- compile_at_path(source_path, stanc_args, compile_args, verbose)
+    dest <- tempfile("nutpieR-untracked-build-")
+    dir.create(dest, recursive = TRUE)
+    copied <- file.path(dest, basename(built))
+    if (!file.copy(built, copied, overwrite = TRUE)) {
+      stop("Could not copy fresh untracked Stan library to ", copied, call. = FALSE)
+    }
+    nutpie_model(
+      lib_path = normalizePath(copied, mustWork = TRUE),
+      stan_file = bundle$display_source,
+      staged_source = source_path
+    )
+  })
+}
 # --- Pruning --------------------------------------------------------------
 
 # Mirrors nutpie's policy: cap the cache at `max_entries` valid entries,

--- a/R/compile.R
+++ b/R/compile.R
@@ -11,9 +11,20 @@
 #' was passed as `stan_file = ...` or `code = "..."`. A subsequent call
 #' with identical inputs is a near-instant cache hit.
 #'
-#' For `stan_file = ...`, the transitive `#include` set is hashed
-#' together with the main file, so editing an included file (or the main
-#' file itself) busts the cache and triggers a recompile.
+#' For either `stan_file = ...` or inline `code = ...`, nutpieR asks the
+#' bundled `stanc` compiler to resolve transitive `#include` files using the
+#' same ordered include paths as compilation. Their bytes are part of the
+#' cache key, so editing an included file (or the main file itself) triggers a
+#' recompile. Include-bearing models are staged as stanc-expanded source. This
+#' makes nested and external includes reliable, but compiler errors for those
+#' models refer to the staged expanded source rather than an original include
+#' line. Unusual stanc output-mode or make/compiler overrides that cannot be
+#' tracked are compiled fresh without using the persistent cache. For a
+#' file-based model, that conservative route compiles in the source directory
+#' under a per-source lock and returns a copied, unique temporary library path.
+#' It requires that source directory to be writable and contain no spaces;
+#' otherwise nutpieR stops with guidance rather than using different compiler
+#' semantics.
 #'
 #' The cache is bounded by [`nutpie_prune_cache()`][nutpie_prune_cache],
 #' which runs automatically at the end of every successful compile
@@ -44,7 +55,10 @@
 #'   `code` must be provided.
 #' @param code A string containing Stan model code.
 #' @param stanc_args Character vector of extra arguments passed to the
-#'   `stanc` compiler (e.g., `"--O1"` for optimization).
+#'   `stanc` compiler (e.g., `"--O1"` for optimization). Repeated
+#'   `--include-paths=` arguments keep their supplied order. Do not use stanc
+#'   output-mode arguments such as `--auto-format` here; if supplied with an
+#'   include model, nutpieR compiles fresh rather than risking a cache hit.
 #' @param compile_args Character vector of extra arguments passed to `make`
 #'   during compilation. On macOS, nutpieR keeps Stan's fast process-wide
 #'   `tbbmalloc_proxy` allocator but patches its bundled source to be safe
@@ -109,10 +123,21 @@ nutpie_compile_model <- function(stan_file = NULL, code = NULL,
   use_cache <- cache &&
     !identical(Sys.getenv("NUTPIER_DISABLE_COMPILE_CACHE"), "1")
 
-  bundle <- if (!is.null(code)) {
-    inline_bundle(code)
-  } else {
-    file_bundle(normalizePath(stan_file, mustWork = TRUE))
+  source_path <- if (is.null(stan_file)) NULL else normalizePath(stan_file, mustWork = TRUE)
+  bundle <- bundle_for_compile(source_path, code, stanc_args, compile_args)
+
+  # If an unusual stanc output-mode override prevents us from obtaining both
+  # compiler-resolved dependencies and expanded source, never claim a cache
+  # hit.  A fresh build is slower but cannot silently reuse an old model.
+  if (isTRUE(attr(bundle, "untracked_includes"))) {
+    warning(
+      "Could not safely track #include dependencies with these `stanc_args`; ",
+      "compiling without the persistent cache.",
+      call. = FALSE
+    )
+    return(compile_no_cache_untracked(
+      bundle, source_path, stanc_args, compile_args, verbose
+    ))
   }
 
   if (use_cache) {

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -6,6 +6,10 @@
 #' @noRd
 bridgestan_version <- function() .Call(wrap__bridgestan_version)
 
+#' Path to the bundled stanc executable used by BridgeStan compilation.
+#' @noRd
+bridgestan_stanc_path <- function() .Call(wrap__bridgestan_stanc_path)
+
 #' Compile a Stan model to a shared library using BridgeStan.
 #' Downloads BridgeStan sources if needed (first call is slow).
 #' @param stan_file Path to the .stan file.

--- a/R/sample.R
+++ b/R/sample.R
@@ -9,11 +9,22 @@
 #'   - A JSON string
 #'   - A path to a `.json` file
 #'   - `NULL` for models with no data block
+#'
+#'   Named-list data use `jsonlite::toJSON(auto_unbox = TRUE, digits = NA)`.
+#'   Scalar values are therefore unboxed, while explicit dimensions are kept.
+#'   Because ordinary length-one vectors and scalars are indistinguishable in
+#'   R, use `I(3)` or `array(3, dim = 1)` for a one-element vector, and use
+#'   `matrix(3, nrow = 1, ncol = 1)` (or an explicitly dimensioned array) for
+#'   a one-by-one matrix. The same rule preserves other singleton axes;
+#'   `numeric(0)` is serialized as `[]`. JSON strings and files are passed
+#'   through without singleton rewriting. No automatic inference is attempted
+#'   for an ordinary length-one vector.
 #' @param num_draws Number of post-warmup draws per chain.
-#' @param num_warmup Number of warmup (tuning) draws per chain. `NULL` (the
-#'   default) uses the nuts-rs adaptation-specific default: `400` for
-#'   `adaptation = "diag"` and `800` for `adaptation = "low_rank"`. An explicit
-#'   value always takes precedence.
+#' @param num_warmup Number of warmup (tuning) draws per chain. Must be
+#'   positive (at least `1`); zero warmup is not supported by nuts-rs
+#'   adaptation. `NULL` (the default) uses the nuts-rs adaptation-specific
+#'   default: `400` for `adaptation = "diag"` and `800` for
+#'   `adaptation = "low_rank"`. An explicit value always takes precedence.
 #' @param num_chains Number of parallel chains.
 #' @param seed Random seed for reproducibility.
 #' @param max_treedepth Maximum tree depth for NUTS. A complete tree at
@@ -442,7 +453,7 @@ resolve_sample_config <- function(seed, adaptation, low_rank_modified_mass_matri
   }
 
   num_draws <- check_count(num_draws, "num_draws", min = 1L)
-  num_warmup <- check_count(num_warmup, "num_warmup", min = 0L)
+  num_warmup <- check_count(num_warmup, "num_warmup", min = 1L)
   num_chains <- check_count(num_chains, "num_chains", min = 1L)
   refresh <- check_count(refresh, "refresh", min = 0L)
   if (is.null(cores)) {

--- a/man/nutpie_compile_model.Rd
+++ b/man/nutpie_compile_model.Rd
@@ -20,7 +20,10 @@ nutpie_compile_model(
 \item{code}{A string containing Stan model code.}
 
 \item{stanc_args}{Character vector of extra arguments passed to the
-\code{stanc} compiler (e.g., \code{"--O1"} for optimization).}
+\code{stanc} compiler (e.g., \code{"--O1"} for optimization). Repeated
+\verb{--include-paths=} arguments keep their supplied order. Do not use stanc
+output-mode arguments such as \code{--auto-format} here; if supplied with an
+include model, nutpieR compiles fresh rather than risking a cache hit.}
 
 \item{compile_args}{Character vector of extra arguments passed to \code{make}
 during compilation. On macOS, nutpieR keeps Stan's fast process-wide
@@ -59,9 +62,20 @@ source + flags + BridgeStan version), regardless of whether the model
 was passed as \code{stan_file = ...} or \code{code = "..."}. A subsequent call
 with identical inputs is a near-instant cache hit.
 
-For \code{stan_file = ...}, the transitive \verb{#include} set is hashed
-together with the main file, so editing an included file (or the main
-file itself) busts the cache and triggers a recompile.
+For either \code{stan_file = ...} or inline \code{code = ...}, nutpieR asks the
+bundled \code{stanc} compiler to resolve transitive \verb{#include} files using the
+same ordered include paths as compilation. Their bytes are part of the
+cache key, so editing an included file (or the main file itself) triggers a
+recompile. Include-bearing models are staged as stanc-expanded source. This
+makes nested and external includes reliable, but compiler errors for those
+models refer to the staged expanded source rather than an original include
+line. Unusual stanc output-mode or make/compiler overrides that cannot be
+tracked are compiled fresh without using the persistent cache. For a
+file-based model, that conservative route compiles in the source directory
+under a per-source lock and returns a copied, unique temporary library path.
+It requires that source directory to be writable and contain no spaces;
+otherwise nutpieR stops with guidance rather than using different compiler
+semantics.
 
 The cache is bounded by \code{\link[=nutpie_prune_cache]{nutpie_prune_cache()}},
 which runs automatically at the end of every successful compile

--- a/man/nutpie_sample.Rd
+++ b/man/nutpie_sample.Rd
@@ -45,14 +45,25 @@ or a path to a compiled shared library.}
 \item A JSON string
 \item A path to a \code{.json} file
 \item \code{NULL} for models with no data block
-}}
+}
+
+Named-list data use \code{jsonlite::toJSON(auto_unbox = TRUE, digits = NA)}.
+Scalar values are therefore unboxed, while explicit dimensions are kept.
+Because ordinary length-one vectors and scalars are indistinguishable in R,
+use \code{I(3)} or \code{array(3, dim = 1)} for a one-element vector, and use
+\code{matrix(3, nrow = 1, ncol = 1)} (or an explicitly dimensioned array) for
+a one-by-one matrix. The same rule preserves other singleton axes;
+\code{numeric(0)} is serialized as \code{[]}. JSON strings and files are passed
+through without singleton rewriting. No automatic inference is attempted for an
+ordinary length-one vector.}
 
 \item{num_draws}{Number of post-warmup draws per chain.}
 
-\item{num_warmup}{Number of warmup (tuning) draws per chain. \code{NULL} (the
-default) uses the nuts-rs adaptation-specific default: \code{400} for
-\code{adaptation = "diag"} and \code{800} for \code{adaptation = "low_rank"}. An explicit
-value always takes precedence.}
+\item{num_warmup}{Number of warmup (tuning) draws per chain. Must be
+positive (at least \code{1}); zero warmup is not supported by nuts-rs
+adaptation. \code{NULL} (the default) uses the nuts-rs adaptation-specific
+default: \code{400} for \code{adaptation = "diag"} and \code{800} for
+\code{adaptation = "low_rank"}. An explicit value always takes precedence.}
 
 \item{num_chains}{Number of parallel chains.}
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -101,6 +101,33 @@ fn bridgestan_version() -> String {
     bridgestan::VERSION.to_string()
 }
 
+/// Return the bundled stanc binary used by BridgeStan compilation.
+///
+/// This is intentionally native rather than reconstructed in R: the source
+/// cache location is owned by the BridgeStan crate and can vary by platform.
+/// @noRd
+#[extendr]
+fn bridgestan_stanc_path() -> String {
+    or_throw(bridgestan_stanc_path_impl())
+}
+
+fn bridgestan_stanc_path_impl() -> Result<String> {
+    let bs_path = bridgestan::download_bridgestan_src().map_err(r_err)?;
+    let executable = if cfg!(target_os = "windows") {
+        "stanc.exe"
+    } else {
+        "stanc"
+    };
+    let path = bs_path.join("bin").join(executable);
+    if !path.is_file() {
+        return Err(Error::Other(format!(
+            "BridgeStan's bundled stanc was not found at {}",
+            path.display()
+        )));
+    }
+    Ok(path.to_string_lossy().into_owned())
+}
+
 /// Compile a Stan model to a shared library using BridgeStan.
 /// Downloads BridgeStan sources if needed (first call is slow).
 /// @param stan_file Path to the .stan file.
@@ -1587,6 +1614,7 @@ fn bs_param_constrain_block_impl(
 extendr_module! {
     mod nutpieR;
     fn bridgestan_version;
+    fn bridgestan_stanc_path;
     fn compile_stan_model;
     fn tbb_proxy_live_progress_safe;
     fn ensure_tbb_proxy_patched;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -813,9 +813,9 @@ fn sample_stan(
                 return Err(Error::Other(format!("{} must be >= 1, got {}", name, val)));
             }
         }
-        if num_warmup < 0 {
+        if num_warmup <= 0 {
             return Err(Error::Other(format!(
-                "num_warmup must be >= 0, got {}",
+                "num_warmup must be >= 1; zero warmup is not supported by nuts-rs adaptation (got {})",
                 num_warmup
             )));
         }

--- a/tests/testthat/test-compile-cache.R
+++ b/tests/testthat/test-compile-cache.R
@@ -284,16 +284,16 @@ test_that("editing an #include'd file invalidates the cache", {
   on.exit(unlink(d, recursive = TRUE), add = TRUE)
   prior <- file.path(d, "priors.stan")
   main <- file.path(d, "main.stan")
-  writeLines("// v1", prior)
+  writeLines("real prior_mean() { return 0; }", prior)
   writeLines(c("functions {", "#include priors.stan", "}",
-               "parameters { real x; } model { x ~ normal(0, 1); }"), main)
+               "parameters { real x; } model { x ~ normal(prior_mean(), 1); }"), main)
 
   nutpie_compile_model(stan_file = main, verbose = 0L)
   expect_equal(counter$n, 1L)
 
   # Touch only the included file. With hash-based invalidation this
   # changes the bundle content -> new hash -> recompile.
-  writeLines("// v2", prior)
+  writeLines("real prior_mean() { return 1; }", prior)
   nutpie_compile_model(stan_file = main, verbose = 0L)
   expect_equal(counter$n, 2L)
 })
@@ -317,24 +317,25 @@ test_that("multi-space, missing, and nested #include all invalidate properly", {
   a <- file.path(d, "a.stan")
   b <- file.path(d, "b.stan")
   c <- file.path(d, "c.stan")
-  writeLines("// c v1", c)
+  writeLines("real nested_mean() { return 0; }", c)
   writeLines(c("// b v1", "#include   c.stan"), b)
   writeLines(c("functions {", "#include  b.stan", "}",
-               "parameters { real x; } model { x ~ normal(0, 1); }"), a)
+               "parameters { real x; } model { x ~ normal(nested_mean(), 1); }"), a)
 
   nutpie_compile_model(stan_file = a, verbose = 0L)
   expect_equal(counter$n, 1L)
 
   # Editing the depth-2 include must invalidate -- proves transitive walk.
-  writeLines("// c v2", c)
+  writeLines("real nested_mean() { return 1; }", c)
   nutpie_compile_model(stan_file = a, verbose = 0L)
   expect_equal(counter$n, 2L)
 
-  # Deleting an included file must invalidate -- a missing dep should
-  # never read as "no constraint" (would silently return a stale .so).
+  # A deleted dependency must not return the prior cache entry.  stanc's own
+  # resolver surfaces the missing file before a cache lookup can occur.
   unlink(c)
-  nutpie_compile_model(stan_file = a, verbose = 0L)
-  expect_equal(counter$n, 3L)
+  expect_error(nutpie_compile_model(stan_file = a, verbose = 0L),
+               "include|c\\.stan|Could not find")
+  expect_equal(counter$n, 2L)
 })
 
 test_that("commented-out #include directives are ignored", {
@@ -360,7 +361,10 @@ test_that("commented-out #include directives are ignored", {
     "parameters { real x; } model { x ~ normal(0, 1); }"
   ), main)
 
-  expect_equal(nutpieR:::included_files(main), character())
+  # The gate may conservatively false-positive on a block comment; stanc,
+  # rather than an R parser, remains the authority and reports no dependency.
+  expect_true(nutpieR:::has_possible_include(nutpieR:::read_dep(main)))
+  expect_length(nutpieR:::resolve_included_source(main, character())$dependencies, 0L)
 
   nutpie_compile_model(stan_file = main, verbose = 0L)
   expect_equal(counter$n, 1L)
@@ -607,4 +611,240 @@ test_that("stan_file with relative #include compiles", {
   m <- nutpie_compile_model(stan_file = file.path(d, "main.stan"),
                             verbose = 0L)
   expect_true(file.exists(m$lib_path))
+})
+
+
+test_that("external include edits invalidate inline cache and change the model", {
+  skip_if_no_make()
+  local_isolated_cache()
+
+  d <- tempfile("nutpieR-external-inline-")
+  inc <- file.path(d, "include")
+  dir.create(inc, recursive = TRUE)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  center <- file.path(inc, "center.stan")
+  writeLines("real center() { return 0; }", center)
+  code <- paste(
+    "functions {", "#include center.stan", "}",
+    "parameters { real x; }", "model { x ~ normal(center(), 0.1); }",
+    sep = "\n"
+  )
+  flags <- paste0("--include-paths=", inc)
+
+  first <- nutpie_compile_model(code = code, stanc_args = flags, verbose = 0L)
+  first_draws <- nutpie_sample(
+    first, data = NULL, num_warmup = 80L, num_draws = 80L,
+    num_chains = 1L, seed = 42L, refresh = 0L
+  )
+  writeLines("real center() { return 10; }", center)
+  second <- nutpie_compile_model(code = code, stanc_args = flags, verbose = 0L)
+  second_draws <- nutpie_sample(
+    second, data = NULL, num_warmup = 80L, num_draws = 80L,
+    num_chains = 1L, seed = 42L, refresh = 0L
+  )
+
+  expect_false(identical(first$lib_path, second$lib_path))
+  expect_lt(mean(as.numeric(first_draws)), 1)
+  expect_gt(mean(as.numeric(second_draws)), 9)
+  # The unchanged expanded source/dependency bytes retain the ordinary hit.
+  expect_identical(
+    nutpie_compile_model(code = code, stanc_args = flags, verbose = 0L)$lib_path,
+    second$lib_path
+  )
+})
+
+test_that("compiler resolution handles nested includes from the main root", {
+  skip_if_no_make()
+  local_isolated_cache()
+
+  d <- tempfile("nutpieR-nested-main-root-")
+  dir.create(file.path(d, "sub"), recursive = TRUE)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  writeLines("real center() { return 0; }", file.path(d, "center.stan"))
+  writeLines("#include center.stan", file.path(d, "sub", "f.stan"))
+  main <- file.path(d, "main.stan")
+  writeLines(c(
+    "functions {", "#include sub/f.stan", "}",
+    "parameters { real x; }", "model { x ~ normal(center(), 1); }"
+  ), main)
+
+  # This also exercises the fresh staging route: no source-tree layout is
+  # assumed after stanc has expanded the include tree.
+  fresh <- nutpie_compile_model(stan_file = main, cache = FALSE, verbose = 0L)
+  expect_true(file.exists(fresh$lib_path))
+
+  cached <- nutpie_compile_model(stan_file = main, verbose = 0L)
+  cached_draws <- nutpie_sample(
+    cached, data = NULL, num_warmup = 80L, num_draws = 80L,
+    num_chains = 1L, seed = 42L, refresh = 0L
+  )
+  writeLines("real center() { return 2; }", file.path(d, "center.stan"))
+  changed <- nutpie_compile_model(stan_file = main, verbose = 0L)
+  changed_draws <- nutpie_sample(
+    changed, data = NULL, num_warmup = 80L, num_draws = 80L,
+    num_chains = 1L, seed = 42L, refresh = 0L
+  )
+  expect_false(identical(cached$lib_path, changed$lib_path))
+  expect_lt(mean(as.numeric(cached_draws)), 1)
+  expect_gt(mean(as.numeric(changed_draws)), 1)
+})
+
+test_that("stanc include search order is retained when resolving dependencies", {
+  skip_if_no_make()
+  d <- tempfile("nutpieR-include-order-")
+  a <- file.path(d, "a")
+  b <- file.path(d, "b")
+  dir.create(a, recursive = TRUE)
+  dir.create(b, recursive = TRUE)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  writeLines("real center() { return 1; }", file.path(a, "center.stan"))
+  writeLines("real center() { return 2; }", file.path(b, "center.stan"))
+  main <- file.path(d, "main.stan")
+  writeLines(c("functions {", "#include center.stan", "}",
+               "parameters { real x; } model { x ~ normal(center(), 1); }"), main)
+
+  first <- nutpieR:::resolve_included_source(
+    main, c(paste0("--include-paths=", a), paste0("--include-paths=", b))
+  )
+  second <- nutpieR:::resolve_included_source(
+    main, c(paste0("--include-paths=", b), paste0("--include-paths=", a))
+  )
+  expect_identical(first$dependencies[[1L]]$path, normalizePath(file.path(a, "center.stan")))
+  expect_identical(second$dependencies[[1L]]$path, normalizePath(file.path(b, "center.stan")))
+})
+
+
+test_that("untrackable stanc output modes bypass the persistent include cache", {
+  local_isolated_cache()
+  counter <- new.env(parent = emptyenv())
+  testthat::local_mocked_bindings(
+    compile_stan_model = make_compile_stub(counter),
+    bs_version = function() "TEST.0",
+    bridgestan_version = function() "TEST.0",
+    .package = "nutpieR"
+  )
+  code <- paste("functions {", "#include external.stan", "}",
+                "parameters { real x; } model {}", sep = "\n")
+  expect_warning(
+    first <- nutpie_compile_model(code = code, stanc_args = "--auto-format", verbose = 0L),
+    "without the persistent cache"
+  )
+  expect_warning(
+    second <- nutpie_compile_model(code = code, stanc_args = "--auto-format", verbose = 0L),
+    "without the persistent cache"
+  )
+  expect_equal(counter$n, 2L)
+  expect_false(identical(first$lib_path, second$lib_path))
+  expect_false(startsWith(normalizePath(first$lib_path), normalizePath(nutpie_cache_dir())))
+})
+
+
+test_that("the include gate has no mid-line directive false negative", {
+  expect_true(nutpieR:::has_possible_include(
+    charToRaw("functions { #include f.stan\n} parameters { real x; } model {}")
+  ))
+})
+
+test_that("make compiler overrides bypass tracking before stanc and retain file root", {
+  local_isolated_cache()
+  counter <- new.env(parent = emptyenv())
+  compile_stub <- make_compile_stub(counter)
+  testthat::local_mocked_bindings(
+    compile_stan_model = function(stan_file, stanc_args, compile_args) {
+      counter$source_lock_seen <- any(grepl(
+        "^\\.nutpieR-untracked-.*\\.lock$",
+        list.files(dirname(stan_file), all.files = TRUE)
+      ))
+      compile_stub(stan_file, stanc_args, compile_args)
+    },
+    bridgestan_stanc_path = function() stop("resolver must not run"),
+    bs_version = function() "TEST.0",
+    bridgestan_version = function() "TEST.0",
+    .package = "nutpieR"
+  )
+  d <- tempfile("nutpieR-untracked-root-")
+  dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  main <- file.path(d, "main.stan")
+  writeLines(c("functions { #include f.stan }", "parameters { real x; } model {}"), main)
+
+  expect_warning(
+    model <- nutpie_compile_model(
+      stan_file = main, compile_args = "STANC=custom-stanc", verbose = 0L
+    ),
+    "without the persistent cache"
+  )
+  expect_equal(counter$n, 1L)
+  # The fallback compiled the user source itself (not a guessed staged tree),
+  # then copied its result to a distinct path for safe dlopen behavior.
+  expect_identical(
+    normalizePath(model$staged_source),
+    normalizePath(main)
+  )
+  expect_false(startsWith(normalizePath(model$lib_path), normalizePath(d)))
+  expect_true(counter$source_lock_seen)
+})
+
+
+test_that("make-local and makefile overrides conservatively disable tracking", {
+  d <- tempfile("nutpieR-make-local-")
+  dir.create(file.path(d, "bin"), recursive = TRUE)
+  dir.create(file.path(d, "make"), recursive = TRUE)
+  fake_stanc <- file.path(d, "bin", "stanc")
+  file.create(fake_stanc)
+  writeLines("# arbitrary local make customization", file.path(d, "make", "local"))
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  expect_true(nutpieR:::stanc_make_override_present(fake_stanc))
+  # These forms are detected before the resolver could invoke bundled stanc.
+  for (arg in c("-f", "-fother.mk", "STANC:=custom", "STANC+=custom",
+                "STANC?=custom", "STANCFLAGS:=--O1", "--eval=STANC=custom",
+                "-ESTANC=custom")) {
+    expect_false(nutpieR:::stanc_tracking_supported(character(), arg))
+  }
+})
+
+test_that("untrackable file source paths with spaces fail before compilation", {
+  d <- tempfile("nutpieR source space ")
+  dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  main <- file.path(d, "main.stan")
+  writeLines(c("functions { #include f.stan }", "parameters { real x; } model {}"), main)
+  expect_error(
+    suppressWarnings(nutpie_compile_model(
+      stan_file = main, compile_args = "STANC=custom", verbose = 0L
+    )),
+    "writable and have no spaces"
+  )
+})
+
+test_that("a newly shadowing main-root include invalidates a file cache entry", {
+  skip_if_no_make()
+  local_isolated_cache()
+  d <- tempfile("nutpieR-new-shadow-")
+  external <- file.path(d, "external")
+  dir.create(external, recursive = TRUE)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  writeLines("real center() { return 0; }", file.path(external, "center.stan"))
+  main <- file.path(d, "main.stan")
+  writeLines(c(
+    "functions { #include center.stan }", "parameters { real x; }",
+    "model { x ~ normal(center(), 0.1); }"
+  ), main)
+  flags <- paste0("--include-paths=", external)
+  before <- nutpie_compile_model(stan_file = main, stanc_args = flags, verbose = 0L)
+  before_draws <- nutpie_sample(
+    before, data = NULL, num_warmup = 80L, num_draws = 80L,
+    num_chains = 1L, seed = 42L, refresh = 0L
+  )
+  # BridgeStan prepends the main source root before user paths.  A newly
+  # present file there must supersede the old external resolution and cache.
+  writeLines("real center() { return 3; }", file.path(d, "center.stan"))
+  after <- nutpie_compile_model(stan_file = main, stanc_args = flags, verbose = 0L)
+  after_draws <- nutpie_sample(
+    after, data = NULL, num_warmup = 80L, num_draws = 80L,
+    num_chains = 1L, seed = 42L, refresh = 0L
+  )
+  expect_false(identical(before$lib_path, after$lib_path))
+  expect_lt(mean(as.numeric(before_draws)), 1)
+  expect_gt(mean(as.numeric(after_draws)), 2)
 })

--- a/tests/testthat/test-nutpieR.R
+++ b/tests/testthat/test-nutpieR.R
@@ -14,9 +14,9 @@ test_that("resolve_data handles NULL", {
   expect_equal(nutpieR:::resolve_data(NULL), "")
 })
 
-test_that("resolve_data handles JSON string", {
-  json <- '{"N": 10}'
-  expect_equal(nutpieR:::resolve_data(json), json)
+test_that("resolve_data leaves JSON strings unchanged", {
+  json <- '{"N": 10, "y": [3]}'
+  expect_identical(nutpieR:::resolve_data(json), json)
 })
 
 test_that("resolve_data handles list without rounding numeric data", {
@@ -28,12 +28,46 @@ test_that("resolve_data handles list without rounding numeric data", {
   expect_equal(parsed$x, x)
 })
 
-test_that("resolve_data handles .json file", {
+test_that("resolve_data preserves explicit singleton dimensions", {
+  result <- nutpieR:::resolve_data(list(
+    scalar_integer = 3L,
+    scalar_real = 3.25,
+    longer_vector = c(1, 2, 3),
+    singleton_vector = I(3),
+    singleton_array = array(3, dim = 1L),
+    row_array = array(c(3, 4), dim = c(1L, 2L)),
+    col_array = array(c(3, 4), dim = c(2L, 1L)),
+    singleton_matrix = matrix(3, nrow = 1L, ncol = 1L),
+    row_matrix = matrix(c(3, 4), nrow = 1L, ncol = 2L),
+    col_matrix = matrix(c(3, 4), nrow = 2L, ncol = 1L),
+    zero = numeric(0)
+  ))
+  expect_match(result, '"scalar_integer":3')
+  expect_match(result, '"scalar_real":3.25')
+  expect_match(result, '"longer_vector":\\[1,2,3\\]')
+  expect_match(result, '"singleton_vector":\\[3\\]')
+  expect_match(result, '"singleton_array":\\[3\\]')
+  expect_match(result, '"row_array":\\[\\[3,4\\]\\]')
+  expect_match(result, '"col_array":\\[\\[3\\],\\[4\\]\\]')
+  expect_match(result, '"singleton_matrix":\\[\\[3\\]\\]')
+  expect_match(result, '"row_matrix":\\[\\[3,4\\]\\]')
+  expect_match(result, '"col_matrix":\\[\\[3\\],\\[4\\]\\]')
+  expect_match(result, '"zero":\\[\\]')
+})
+
+test_that("resolve_data keeps full numeric precision", {
+  x <- 0.123456789012345
+  result <- nutpieR:::resolve_data(list(x = x))
+  expect_match(result, '0\\.123456789012345')
+  expect_equal(jsonlite::fromJSON(result)$x, x)
+})
+
+test_that("resolve_data leaves .json file contents unchanged", {
   tmp <- tempfile(fileext = ".json")
   on.exit(unlink(tmp))
-  writeLines('{"N": 5}', tmp)
-  result <- nutpieR:::resolve_data(tmp)
-  expect_equal(jsonlite::fromJSON(result)$N, 5)
+  json <- '{"N": 5, "y": [3]}'
+  writeChar(json, tmp, eos = NULL)
+  expect_identical(nutpieR:::resolve_data(tmp), json)
 })
 
 test_that("resolve_data rejects invalid input", {
@@ -56,6 +90,76 @@ test_that("check_count enforces optional max", {
     "must be <= 5"
   )
   expect_equal(nutpieR:::check_count(5L, "seed", min = 0L, max = 5L), 5L)
+})
+
+test_that("num_warmup rejects zero for both adaptation strategies", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  for (adaptation in c("diag", "low_rank")) {
+    expect_error(
+      nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                    num_draws = 2, num_warmup = 0, num_chains = 1,
+                    seed = 1L, refresh = 0, adaptation = adaptation),
+      "num_warmup.*(positive|at least 1|>= 1)"
+    )
+  }
+})
+
+test_that("positive warmup remains usable for both adaptation strategies", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  for (adaptation in c("diag", "low_rank")) {
+    expect_s3_class(
+      nutpie_sample(test_models$bernoulli, data = bernoulli_data(),
+                    num_draws = 2, num_warmup = 1, num_chains = 1,
+                    seed = 1L, refresh = 0, adaptation = adaptation),
+      "draws_array"
+    )
+  }
+})
+
+test_that("explicit singleton vector data reaches the Stan model", {
+  skip_if(is.null(test_models$normal), "Normal model not compiled")
+  for (y in list(I(3), array(3, dim = 1L))) {
+    draws <- nutpie_sample(
+      test_models$normal,
+      data = list(N = 1L, y = y),
+      num_draws = 2, num_warmup = 1, num_chains = 1,
+      seed = 1L, refresh = 0
+    )
+    expect_s3_class(draws, "draws_array")
+  }
+})
+
+test_that("zero-length array data remains usable when Stan permits it", {
+  skip_if(is.null(test_models$bernoulli), "Bernoulli model not compiled")
+  draws <- nutpie_sample(
+    test_models$bernoulli,
+    data = list(N = 0L, y = integer(0)),
+    num_draws = 2, num_warmup = 1, num_chains = 1,
+    seed = 1L, refresh = 0
+  )
+  expect_s3_class(draws, "draws_array")
+})
+
+test_that("native sample_stan rejects zero warmup before constructing sampler", {
+  skip_if(is.null(test_models$normal), "Normal model not compiled")
+  handle <- open_normal_handle()
+  common <- list(
+    handle = handle, num_draws = 2L, num_warmup = 0L, num_chains = 1L,
+    seed = 1L, init_positions = NULL, jitter = FALSE, save_warmup = FALSE,
+    num_cores = 1L, store_divergences = FALSE, store_mass_matrix = FALSE,
+    store_unconstrained = FALSE, store_gradient = FALSE,
+    max_treedepth = NULL, mindepth = NULL, target_accept = NULL,
+    max_energy_error = NULL, extra_doublings = NULL, mass_matrix_gamma = NULL,
+    eigval_cutoff = NULL, keep_indices = NULL, include_tp = TRUE,
+    include_gq = TRUE, progress_callback = NULL
+  )
+  for (adaptation in c("diag", "low_rank")) {
+    expect_error(
+      do.call(nutpieR:::sample_stan,
+              modifyList(common, list(adaptation = adaptation))),
+      "num_warmup.*(positive|at least 1|>= 1)"
+    )
+  }
 })
 
 test_that("nutpie_sample rejects malformed seed", {


### PR DESCRIPTION
## TL;DR

Fix stale cache hits for Stan includes and two small data/sampling boundary issues in 1.8.7.

- Track external and nested `#include` files for file and inline models, using stanc's search order.
- Document singleton data with `I(3)` or explicit array/matrix dimensions.
- Reject zero warmup with a clear error instead of a sampler panic.

No sampler dependency changes.

Include models use expanded source, so diagnostic line locations change. Unsupported compiler overrides bypass the cache; that fallback needs a writable source path without spaces.

## Testing

- Fresh 1.8.7 release build on macOS arm64: 566 default expectations and 44 posteriorDB expectations passed, no failures/warnings.
- Independent real-model probes passed: nested include edits/deletion, newly shadowed inline includes, unchanged cache hits, `cache = FALSE`, and a self-contained control. Checked loaded model behavior, not just library paths.
- `cargo check` passed. Package check clean (`--no-install --no-tests --no-manual`; release install and tests run separately).

Windows/Linux were not tested locally.
